### PR TITLE
Make crate compatible with stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 
 [features]
+unstable = []
 
 [dependencies]
 futures-core = "0.3.16"

--- a/src/join/array.rs
+++ b/src/join/array.rs
@@ -68,7 +68,11 @@ where
             use core::mem::MaybeUninit;
 
             // Create the result array based on the indices
-            let mut out: [MaybeUninit<F::Output>; N] = MaybeUninit::uninit_array();
+            let mut out: [MaybeUninit<F::Output>; N] = {
+                // inlined version of unstable `MaybeUninit::uninit_array()`
+                // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
+                unsafe { MaybeUninit::<[MaybeUninit<_>; N]>::uninit().assume_init() }
+            };
 
             // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
             #[allow(clippy::clippy::needless_range_loop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 //!
 //! The purpose of this library is to serve as a staging ground for what
 //! eventually may become the futures concurrency methods provided by the
-//! stdlib. As such we make liberal use of nightly features, as that's what will
-//! be available to us in the stdlib as well. __Use a nightly compiler to use this library.__
+//! stdlib. While most of this library is compatible with stable Rust, some
+//! functions require nightly features. To use these functions, enable the
+//! `unstable` feature of this crate (requires a nightly compiler).
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub)]
 #![allow(non_snake_case)]
-#![feature(maybe_uninit_uninit_array)]
 #![feature(array_methods)]
-#![feature(array_from_fn)]
 
 mod join;
 mod merge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub)]
 #![allow(non_snake_case)]
-#![feature(array_methods)]
+#![cfg_attr(feature = "unstable", feature(array_methods))]
 
 mod join;
 mod merge;

--- a/src/merge/array.rs
+++ b/src/merge/array.rs
@@ -58,7 +58,17 @@ where
         // Randomize the indexes into our streams array. This ensures that when
         // multiple streams are ready at the same time, we don't accidentally
         // exhaust one stream before another.
-        let mut arr: [usize; N] = core::array::from_fn(|n| n);
+        let mut arr: [usize; N] = {
+            // this is an inlined version of `core::array::from_fn`
+            // TODO: replace this with `core::array::from_fn` when it becomes stable
+            let cb = |n| n;
+            let mut idx = 0;
+            [(); N].map(|_| {
+                let res = cb(idx);
+                idx += 1;
+                res
+            })
+        };
         arr.sort_by_cached_key(|_| utils::random(1000));
 
         // Iterate over our streams one-by-one. If a stream yields a value,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,5 +12,8 @@ mod rng;
 
 pub(crate) use fuse::Fuse;
 pub(crate) use maybe_done::MaybeDone;
-pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, pin_project_array};
+pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut};
 pub(crate) use rng::random;
+
+#[cfg(feature = "unstable")]
+pub(crate) use pin::pin_project_array;

--- a/src/utils/pin.rs
+++ b/src/utils/pin.rs
@@ -12,6 +12,7 @@ pub(crate) fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<
 }
 
 // From: Yosh made this one up, hehehe
+#[cfg(feature = "unstable")]
 pub(crate) fn pin_project_array<T, const N: usize>(slice: Pin<&mut [T; N]>) -> [Pin<&mut T>; N] {
     // SAFETY: `std` _could_ make this unsound if it were to decide Pin's
     // invariants aren't required to transmit through arrays. Otherwise this has


### PR DESCRIPTION
Hi, I saw your great post about the shortcomings of `select!` and your proposed `Stream::merge` operator. I would like to try to replace `select!`s with the `merge` operator in some projects that are targeting stable Rust. To make this possible, this PR tries to remove the nightly requirement of this crate.

Out of the three uses of nightly features, two can be replaced by inlining the respective unstable functions (their implementations use no nightly features). The third feature, `array_methods`, is only used in an internal function that appears to be unused. Given that this crate is for experimentation, I still kept it, but moved it behind a new `unstable` cargo feature. I also updated the crate docs with a note that some features are only available on nightly. While this statement isn't true right now, it allows you to freely experiment with unstable features in future versions of this crate.

Let me know what you think of this approach. And thanks for your work to make async Rust better!