### PR TITLE
Fix merge implementation on tuples

### DIFF
--- a/src/merge/tuple.rs
+++ b/src/merge/tuple.rs
@@ -6,6 +6,22 @@ use futures_core::Stream;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+macro_rules! poll_in_order {
+    ($cx:expr, $stream:expr) => { $stream.poll_next($cx) };
+    ($cx:expr, $stream:expr, $($next:tt),*) => {{
+        let mut pending = false;
+        match $stream.poll_next($cx) {
+            Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
+            Poll::Pending => { pending = true; }
+            Poll::Ready(None) => {},
+        }
+        match poll_in_order!($cx, $($next),*) {
+            Poll::Ready(None) if pending => Poll::Pending,
+            other => other,
+        }
+    }};
+}
+
 impl<T, S0, S1> MergeTrait for (S0, S1)
 where
     S0: IntoStream<Item = T>,
@@ -59,28 +75,10 @@ where
         let s0 = unsafe { Pin::new_unchecked(&mut this.streams.0) };
         let s1 = unsafe { Pin::new_unchecked(&mut this.streams.1) };
         match utils::random(2) {
-            0 => poll_next_in_order(s0, s1, cx),
-            1 => poll_next_in_order(s1, s0, cx),
+            0 => poll_in_order!(cx, s0, s1),
+            1 => poll_in_order!(cx, s1, s0),
             _ => unreachable!(),
         }
-    }
-}
-fn poll_next_in_order<S0, S1, T>(
-    s0: Pin<&mut S0>,
-    s1: Pin<&mut S1>,
-    cx: &mut Context<'_>,
-) -> Poll<Option<T>>
-where
-    S0: Stream<Item = T>,
-    S1: Stream<Item = T>,
-{
-    match s0.poll_next(cx) {
-        Poll::Ready(None) => s1.poll_next(cx),
-        Poll::Ready(item) => Poll::Ready(item),
-        Poll::Pending => match s1.poll_next(cx) {
-            Poll::Ready(None) | Poll::Pending => Poll::Pending,
-            Poll::Ready(item) => Poll::Ready(item),
-        },
     }
 }
 
@@ -117,6 +115,7 @@ pub struct Merge3<T, S0, S1, S2>
 where
     S0: Stream<Item = T>,
     S1: Stream<Item = T>,
+    S2: Stream<Item = T>,
 {
     streams: (S0, S1, S2),
 }
@@ -141,42 +140,18 @@ where
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        fn poll_next_in_order<S0, S1, S2, T>(
-            s0: Pin<&mut S0>,
-            s1: Pin<&mut S1>,
-            s2: Pin<&mut S2>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Option<T>>
-        where
-            S0: Stream<Item = T>,
-            S1: Stream<Item = T>,
-            S2: Stream<Item = T>,
-        {
-            match s0.poll_next(cx) {
-                Poll::Ready(None) => s1.poll_next(cx),
-                Poll::Ready(item) => Poll::Ready(item),
-                Poll::Pending => match s1.poll_next(cx) {
-                    Poll::Ready(None) => s2.poll_next(cx),
-                    Poll::Ready(item) => Poll::Ready(item),
-                    Poll::Pending => match s2.poll_next(cx) {
-                        Poll::Ready(None) | Poll::Pending => Poll::Pending,
-                        Poll::Ready(item) => Poll::Ready(item),
-                    },
-                },
-            }
-        }
         let this = self.project();
         // SAFETY: we're manually projecting the tuple fields here.
         let s0 = unsafe { Pin::new_unchecked(&mut this.streams.0) };
         let s1 = unsafe { Pin::new_unchecked(&mut this.streams.1) };
         let s2 = unsafe { Pin::new_unchecked(&mut this.streams.2) };
         match utils::random(6) {
-            0 => poll_next_in_order(s0, s1, s2, cx),
-            1 => poll_next_in_order(s0, s2, s1, cx),
-            2 => poll_next_in_order(s1, s0, s2, cx),
-            3 => poll_next_in_order(s1, s2, s0, cx),
-            4 => poll_next_in_order(s2, s0, s1, cx),
-            5 => poll_next_in_order(s2, s1, s0, cx),
+            0 => poll_in_order!(cx, s0, s1, s2),
+            1 => poll_in_order!(cx, s0, s2, s1),
+            2 => poll_in_order!(cx, s1, s0, s2),
+            3 => poll_in_order!(cx, s1, s2, s0),
+            4 => poll_in_order!(cx, s2, s0, s1),
+            5 => poll_in_order!(cx, s2, s1, s0),
             _ => unreachable!(),
         }
     }

--- a/src/merge/tuple.rs
+++ b/src/merge/tuple.rs
@@ -156,3 +156,126 @@ where
         }
     }
 }
+impl<T, S0, S1, S2, S3> MergeTrait for (S0, S1, S2, S3)
+where
+    S0: IntoStream<Item = T>,
+    S1: IntoStream<Item = T>,
+    S2: IntoStream<Item = T>,
+    S3: IntoStream<Item = T>,
+{
+    type Item = T;
+    type Stream = Merge4<T, S0::IntoStream, S1::IntoStream, S2::IntoStream, S3::IntoStream>;
+
+    fn merge(self) -> Self::Stream {
+        Merge4::new((
+            self.0.into_stream(),
+            self.1.into_stream(),
+            self.2.into_stream(),
+            self.3.into_stream(),
+        ))
+    }
+}
+
+/// A stream that merges multiple streams into a single stream.
+///
+/// This `struct` is created by the [`merge`] method on [`Stream`]. See its
+/// documentation for more.
+///
+/// [`merge`]: trait.Stream.html#method.merge
+/// [`Stream`]: trait.Stream.html
+#[derive(Debug)]
+#[pin_project::pin_project]
+pub struct Merge4<T, S0, S1, S2, S3>
+where
+    S0: Stream<Item = T>,
+    S1: Stream<Item = T>,
+    S2: Stream<Item = T>,
+    S3: Stream<Item = T>,
+{
+    streams: (S0, S1, S2, S3),
+}
+
+impl<T, S0, S1, S2, S3> Merge4<T, S0, S1, S2, S3>
+where
+    S0: Stream<Item = T>,
+    S1: Stream<Item = T>,
+    S2: Stream<Item = T>,
+    S3: Stream<Item = T>,
+{
+    pub(crate) fn new(streams: (S0, S1, S2, S3)) -> Self {
+        Self { streams }
+    }
+}
+
+impl<T, S0, S1, S2, S3> Stream for Merge4<T, S0, S1, S2, S3>
+where
+    S0: Stream<Item = T>,
+    S1: Stream<Item = T>,
+    S2: Stream<Item = T>,
+    S3: Stream<Item = T>,
+{
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        // SAFETY: we're manually projecting the tuple fields here.
+        let s0 = unsafe { Pin::new_unchecked(&mut this.streams.0) };
+        let s1 = unsafe { Pin::new_unchecked(&mut this.streams.1) };
+        let s2 = unsafe { Pin::new_unchecked(&mut this.streams.2) };
+        let s3 = unsafe { Pin::new_unchecked(&mut this.streams.3) };
+        match utils::random(10) {
+            // s0 first
+            0 => poll_in_order!(cx, s0, s1, s2, s3),
+            1 => poll_in_order!(cx, s0, s1, s3, s2),
+            2 => poll_in_order!(cx, s0, s2, s1, s3),
+            3 => poll_in_order!(cx, s0, s2, s3, s1),
+            4 => poll_in_order!(cx, s0, s3, s1, s2),
+            5 => poll_in_order!(cx, s0, s3, s2, s1),
+            // s1 first
+            6 => poll_in_order!(cx, s1, s0, s2, s3),
+            7 => poll_in_order!(cx, s1, s0, s3, s2),
+            8 => poll_in_order!(cx, s1, s2, s0, s3),
+            9 => poll_in_order!(cx, s1, s2, s3, s0),
+            10 => poll_in_order!(cx, s1, s3, s0, s2),
+            11 => poll_in_order!(cx, s1, s3, s2, s0),
+            // s2 first
+            12 => poll_in_order!(cx, s2, s0, s1, s3),
+            13 => poll_in_order!(cx, s2, s0, s3, s1),
+            14 => poll_in_order!(cx, s2, s1, s0, s3),
+            15 => poll_in_order!(cx, s2, s1, s3, s0),
+            16 => poll_in_order!(cx, s2, s3, s0, s1),
+            17 => poll_in_order!(cx, s2, s3, s1, s0),
+            // s3 first
+            18 => poll_in_order!(cx, s3, s0, s1, s2),
+            19 => poll_in_order!(cx, s3, s0, s2, s1),
+            20 => poll_in_order!(cx, s3, s1, s0, s2),
+            21 => poll_in_order!(cx, s3, s1, s2, s0),
+            22 => poll_in_order!(cx, s3, s2, s0, s1),
+            23 => poll_in_order!(cx, s3, s2, s1, s0),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_tuple_4() {
+        use futures_lite::future::block_on;
+        use futures_lite::{stream, StreamExt};
+
+        block_on(async {
+            let a = stream::once(1);
+            let b = stream::once(2);
+            let c = stream::once(3);
+            let d = stream::once(4);
+            let s = (a, b, c, d).merge();
+
+            let mut counter = 0;
+            s.for_each(|n| counter += n).await;
+            assert_eq!(counter, 10);
+        })
+    }
+}


### PR DESCRIPTION
Add a recursive `poll_in_order!` macro and use it for implementing `Merge` on tuples. This fixes merging for 3-tuples, which was broken because the previous `poll_next_in_order` function did no longer poll `s2` after `s0` finished: https://github.com/yoshuawuyts/futures-concurrency/blob/53266472d28074054b064372440714bc630cd21b/src/merge/tuple.rs#L156

To utilize the new macro, this PR also adds a `Stream` implementation for 4-tuples. It still requires a lot of boilerplate, but at least the repetitive matching on `poll_next` is now autogenerated.

I also tried to create a macro to autogenerate the `MergeX` structs and trait impl blocks, but I didn't find a way to permutate the list of streams in a macro.


Fixes #3 