### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/utils/maybe_done.rs
+++ b/src/utils/maybe_done.rs
@@ -42,8 +42,8 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// towards completion.
     #[inline]
     pub(crate) fn take(self: Pin<&mut Self>) -> Option<Fut::Output> {
-        unsafe {
-            let this = self.get_unchecked_mut();
+        
+            let this = unsafe { self.get_unchecked_mut() };
             match this {
                 MaybeDone::Done(_) => {}
                 MaybeDone::Future(_) | MaybeDone::Gone => return None,
@@ -53,7 +53,7 @@ impl<Fut: Future> MaybeDone<Fut> {
             } else {
                 unreachable!()
             }
-        }
+        
     }
 }
 

--- a/src/utils/maybe_done.rs
+++ b/src/utils/maybe_done.rs
@@ -42,18 +42,16 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// towards completion.
     #[inline]
     pub(crate) fn take(self: Pin<&mut Self>) -> Option<Fut::Output> {
-        
-            let this = unsafe { self.get_unchecked_mut() };
-            match this {
-                MaybeDone::Done(_) => {}
-                MaybeDone::Future(_) | MaybeDone::Gone => return None,
-            };
-            if let MaybeDone::Done(output) = mem::replace(this, MaybeDone::Gone) {
-                Some(output)
-            } else {
-                unreachable!()
-            }
-        
+        let this = unsafe { self.get_unchecked_mut() };
+        match this {
+            MaybeDone::Done(_) => {}
+            MaybeDone::Future(_) | MaybeDone::Gone => return None,
+        };
+        if let MaybeDone::Done(output) = mem::replace(this, MaybeDone::Gone) {
+            Some(output)
+        } else {
+            unreachable!()
+        }
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html