### PR TITLE
move off async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ unstable = []
 [dependencies]
 futures-core = "0.3.16"
 pin-project = "1.0.8"
-async-trait = "0.1.52"
 
 [dev-dependencies]
 futures-lite = "1.12.0"

--- a/src/first_ok/array.rs
+++ b/src/first_ok/array.rs
@@ -53,7 +53,6 @@ impl<E, const N: usize> DerefMut for AggregateError<E, N> {
 
 impl<E: fmt::Debug, const N: usize> std::error::Error for AggregateError<E, N> {}
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, T, E, const N: usize> FirstOkTrait for [Fut; N]
 where
     T: fmt::Debug,
@@ -62,12 +61,12 @@ where
 {
     type Output = T;
     type Error = AggregateError<E, N>;
+    type Future = FirstOk<Fut::IntoFuture, T, E, N>;
 
-    async fn first_ok(self) -> Result<Self::Output, Self::Error> {
+    fn first_ok(self) -> Self::Future {
         FirstOk {
             elems: self.map(|fut| MaybeDone::new(fut.into_future())),
         }
-        .await
     }
 }
 

--- a/src/first_ok/mod.rs
+++ b/src/first_ok/mod.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 pub(crate) mod array;
 pub(crate) mod vec;
 
@@ -6,7 +8,6 @@ pub(crate) mod vec;
 /// Awaits multiple futures simultaneously, returning the output of the first
 /// future which completes. If no future completes successfully, returns an
 /// aggregate error of all failed futures.
-#[async_trait::async_trait(?Send)]
 pub trait FirstOk {
     /// The resulting output type.
     type Output;
@@ -14,6 +15,9 @@ pub trait FirstOk {
     /// The resulting error type.
     type Error;
 
+    /// Which kind of future are we turning this into?
+    type Future: Future<Output = Result<Self::Output, Self::Error>>;
+
     /// Waits for the first successful future to complete.
-    async fn first_ok(self) -> Result<Self::Output, Self::Error>;
+    fn first_ok(self) -> Self::Future;
 }

--- a/src/first_ok/vec.rs
+++ b/src/first_ok/vec.rs
@@ -56,7 +56,6 @@ impl<E> DerefMut for AggregateError<E> {
 
 impl<E: fmt::Debug> std::error::Error for AggregateError<E> {}
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, T, E> FirstOkTrait for Vec<Fut>
 where
     T: fmt::Debug,
@@ -65,8 +64,9 @@ where
 {
     type Output = T;
     type Error = AggregateError<E>;
+    type Future = FirstOk<Fut::IntoFuture, T, E>;
 
-    async fn first_ok(self) -> Result<Self::Output, Self::Error> {
+    fn first_ok(self) -> Self::Future {
         let elems: Box<[_]> = self
             .into_iter()
             .map(|fut| MaybeDone::new(fut.into_future()))
@@ -74,7 +74,6 @@ where
         FirstOk {
             elems: elems.into(),
         }
-        .await
     }
 }
 

--- a/src/join/array.rs
+++ b/src/join/array.rs
@@ -8,18 +8,16 @@ use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, const N: usize> JoinTrait for [Fut; N]
 where
     Fut: IntoFuture,
 {
     type Output = [Fut::Output; N];
-
-    async fn join(self) -> Self::Output {
+    type Future = Join<Fut::IntoFuture, N>;
+    fn join(self) -> Self::Future {
         Join {
             elems: self.map(|fut| MaybeDone::new(fut.into_future())),
         }
-        .await
     }
 }
 

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 pub(crate) mod array;
 pub(crate) mod tuple;
 pub(crate) mod vec;
@@ -6,10 +8,12 @@ pub(crate) mod vec;
 ///
 /// Awaits multiple futures simultaneously, returning the output of the futures
 /// once both complete.
-#[async_trait::async_trait(?Send)]
 pub trait Join {
     /// The resulting output type.
     type Output;
+
+    /// Which kind of future are we turning this into?
+    type Future: Future<Output = Self::Output>;
 
     /// Waits for multiple futures to complete.
     ///
@@ -18,5 +22,5 @@ pub trait Join {
     ///
     /// This function returns a new future which polls both futures
     /// concurrently.
-    async fn join(self) -> Self::Output;
+    fn join(self) -> Self::Future;
 }

--- a/src/join/tuple.rs
+++ b/src/join/tuple.rs
@@ -17,7 +17,7 @@ macro_rules! generate {
         #[pin_project]
         #[must_use = "futures do nothing unless you `.await` or poll them"]
         #[allow(non_snake_case)]
-        pub(crate) struct $TyName<$($Fut: Future),*> {
+        pub struct $TyName<$($Fut: Future),*> {
             $(#[pin] $Fut: MaybeDone<$Fut>,)*
         }
 
@@ -35,7 +35,6 @@ macro_rules! generate {
             }
         }
 
-        #[async_trait::async_trait(?Send)]
         impl<$($Fut),*> JoinTrait for ($($Fut),*)
         where
             $(
@@ -43,12 +42,13 @@ macro_rules! generate {
             )*
         {
             type Output = ($($Fut::Output),*);
+            type Future = $TyName<$($Fut::IntoFuture),*>;
 
-            async fn join(self) -> Self::Output {
+            fn join(self) -> Self::Future {
                 let ($($Fut),*): ($($Fut),*) = self;
                 $TyName {
                     $($Fut: MaybeDone::new($Fut.into_future())),*
-                }.await
+                }
             }
         }
 

--- a/src/join/vec.rs
+++ b/src/join/vec.rs
@@ -10,22 +10,21 @@ use core::task::{Context, Poll};
 use std::boxed::Box;
 use std::vec::Vec;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut> JoinTrait for Vec<Fut>
 where
     Fut: IntoFuture,
 {
     type Output = Vec<Fut::Output>;
+    type Future = Join<Fut::IntoFuture>;
 
-    async fn join(self) -> Self::Output {
-        let elems: Box<[_]> = self
-            .into_iter()
-            .map(|fut| MaybeDone::new(fut.into_future()))
-            .collect();
+    fn join(self) -> Self::Future {
         Join {
-            elems: elems.into(),
+            elems: self
+                .into_iter()
+                .map(|fut| MaybeDone::new(fut.into_future()))
+                .collect::<Box<_>>()
+                .into(),
         }
-        .await
     }
 }
 

--- a/src/race/array.rs
+++ b/src/race/array.rs
@@ -7,19 +7,18 @@ use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, const N: usize> RaceTrait for [Fut; N]
 where
     Fut: IntoFuture,
 {
     type Output = Fut::Output;
+    type Future = Race<Fut::IntoFuture, N>;
 
-    async fn race(self) -> Self::Output {
+    fn race(self) -> Self::Future {
         Race {
             futs: self.map(|fut| fut.into_future()),
             done: false,
         }
-        .await
     }
 }
 

--- a/src/race/mod.rs
+++ b/src/race/mod.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 pub(crate) mod array;
 pub(crate) mod tuple;
 pub(crate) mod vec;
@@ -6,10 +8,12 @@ pub(crate) mod vec;
 ///
 /// Awaits multiple futures simultaneously, returning the output of the first
 /// future which completes.
-#[async_trait::async_trait(?Send)]
 pub trait Race {
     /// The resulting output type.
     type Output;
+
+    /// Which kind of future are we turning this into?
+    type Future: Future<Output = Self::Output>;
 
     /// Waits for multiple futures to complete.
     ///
@@ -18,5 +22,5 @@ pub trait Race {
     ///
     /// This function returns a new future which polls both futures
     /// concurrently.
-    async fn race(self) -> Self::Output;
+    fn race(self) -> Self::Future;
 }

--- a/src/race/tuple.rs
+++ b/src/race/tuple.rs
@@ -16,7 +16,7 @@ macro_rules! generate {
         #[pin_project]
         #[must_use = "futures do nothing unless you `.await` or poll them"]
         #[allow(non_snake_case)]
-        pub(crate) struct $TyName<T, $($Fut),*>
+        pub struct $TyName<T, $($Fut),*>
         where
             $($Fut: Future<Output = T>),*
         {
@@ -38,19 +38,19 @@ macro_rules! generate {
             }
         }
 
-        #[async_trait::async_trait(?Send)]
         impl<T, $($Fut),*> RaceTrait for ($($Fut),*)
         where
             $($Fut: IntoFuture<Output = T>),*
         {
             type Output = T;
+            type Future = $TyName<T, $($Fut::IntoFuture),*>;
 
-            async fn race(self) -> Self::Output {
+            fn race(self) -> Self::Future {
                 let ($($Fut),*): ($($Fut),*) = self;
                 $TyName {
                     done: false,
                     $($Fut: $Fut.into_future()),*
-                }.await
+                }
             }
         }
 

--- a/src/race/vec.rs
+++ b/src/race/vec.rs
@@ -7,19 +7,18 @@ use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut> RaceTrait for Vec<Fut>
 where
     Fut: IntoFuture,
 {
     type Output = Fut::Output;
+    type Future = Race<Fut::IntoFuture>;
 
-    async fn race(self) -> Self::Output {
+    fn race(self) -> Self::Future {
         Race {
             futs: self.into_iter().map(|fut| fut.into_future()).collect(),
             done: false,
         }
-        .await
     }
 }
 

--- a/src/try_join/array.rs
+++ b/src/try_join/array.rs
@@ -8,21 +8,20 @@ use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, T, E, const N: usize> TryJoinTrait for [Fut; N]
 where
     T: std::fmt::Debug,
-    Fut: Future<Output = Result<T, E>>,
+    Fut: IntoFuture<Output = Result<T, E>>,
     E: fmt::Debug,
 {
     type Output = [T; N];
     type Error = E;
+    type Future = TryJoin<Fut::IntoFuture, T, E, N>;
 
-    async fn try_join(self) -> Result<Self::Output, Self::Error> {
+    fn try_join(self) -> Self::Future {
         TryJoin {
             elems: self.map(|fut| MaybeDone::new(fut.into_future())),
         }
-        .await
     }
 }
 

--- a/src/try_join/mod.rs
+++ b/src/try_join/mod.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 pub(crate) mod array;
 pub(crate) mod vec;
 
@@ -8,7 +10,6 @@ pub(crate) mod vec;
 ///
 /// If you want to keep partial data in the case of failure, see the `merge`
 /// operation.
-#[async_trait::async_trait(?Send)]
 pub trait TryJoin {
     /// The resulting output type.
     type Output;
@@ -16,8 +17,11 @@ pub trait TryJoin {
     /// The resulting error type.
     type Error;
 
+    /// Which kind of future are we turning this into?
+    type Future: Future<Output = Result<Self::Output, Self::Error>>;
+
     /// Waits for multiple futures to complete, either returning when all
     /// futures complete successfully, or return early when any future completes
     /// with an error.
-    async fn try_join(self) -> Result<Self::Output, Self::Error>;
+    fn try_join(self) -> Self::Future;
 }

--- a/src/try_join/vec.rs
+++ b/src/try_join/vec.rs
@@ -10,16 +10,16 @@ use core::task::{Context, Poll};
 use std::boxed::Box;
 use std::vec::Vec;
 
-#[async_trait::async_trait(?Send)]
 impl<Fut, T, E> TryJoinTrait for Vec<Fut>
 where
     T: std::fmt::Debug,
-    Fut: Future<Output = Result<T, E>>,
+    Fut: IntoFuture<Output = Result<T, E>>,
 {
     type Output = Vec<T>;
     type Error = E;
+    type Future = TryJoin<Fut::IntoFuture, T, E>;
 
-    async fn try_join(self) -> Result<Self::Output, Self::Error> {
+    fn try_join(self) -> Self::Future {
         let elems: Box<[_]> = self
             .into_iter()
             .map(|fut| MaybeDone::new(fut.into_future()))
@@ -27,7 +27,6 @@ where
         TryJoin {
             elems: elems.into(),
         }
-        .await
     }
 }
 


### PR DESCRIPTION
Spelling out the associated future is actually fine here since:
1. there is no parity with non-async traits (this is all about async-only concurrency)
2. it's a trivial conversion into a named future struct, which means the `async fn` doesn't buy us anything really
3. the main target is stdlib types; third-party types are quite unlikely to implement this

Having an async trait only really complicates the implementation, and relies on not-yet-implemented features such as `impl trait` for `async fn` aliases which don't yet exist.