### PR TITLE
implement `stream::Merge` for tuples up to length 12

### DIFF
--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -22,20 +22,8 @@ const fn permutations(mut num: u32) -> u32 {
 
 /// Calculate the number of tuples currently being operated on.
 macro_rules! tuple_len {
-    // Increment the counter.
-    (@inner $counter:expr, $F:ident, $($rest:ident,)*) => {
-        tuple_len!(@inner $counter + 1, $($rest,)*)
-    };
-
-    // End of recursion.
-    (@inner $counter:expr,) => {
-        $counter
-    };
-
-    // Base condition.
-    ($($F:ident,)*) => {
-        tuple_len!(@inner 0, $($F,)*)
-    }
+    (@count_one $F:ident) => (1);
+    ($($F:ident,)*) => (0 $(+ tuple_len!(@count_one $F))*);
 }
 
 /// Generate the `match` conditions inside the main `poll_next` body. This macro

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 /// Compute the number of permutations for a number
+/// during compilation.
 const fn permutations(mut num: u32) -> u32 {
     let mut total = 1;
     loop {
@@ -19,251 +20,138 @@ const fn permutations(mut num: u32) -> u32 {
     total
 }
 
-macro_rules! poll_in_order {
-    ($cx:expr, $stream:expr) => { $stream.poll_next($cx) };
-    ($cx:expr, $stream:expr, $($next:tt),*) => {{
-        let mut pending = false;
-        match $stream.poll_next($cx) {
-            Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
-            Poll::Pending => { pending = true; }
-            Poll::Ready(None) => {},
-        }
-        match poll_in_order!($cx, $($next),*) {
-            Poll::Ready(None) if pending => Poll::Pending,
-            other => other,
-        }
-    }};
-}
+/// Calculate the number of tuples currently being operated on.
+macro_rules! tuple_len {
+    // Increment the counter.
+    (@inner $counter:expr, $F:ident, $($rest:ident,)*) => {
+        tuple_len!(@inner $counter + 1, $($rest,)*)
+    };
 
-macro_rules! poll_and_then_return {
-    ($stream:expr, $cx:expr) => {{
-        if let Poll::Ready(value) = unsafe { Pin::new_unchecked($stream) }.poll_next($cx) {
-            return Poll::Ready(value);
-        }
-    }};
-}
+    // End of recursion.
+    (@inner $counter:expr,) => {
+        $counter
+    };
 
-impl<T, A, B> MergeTrait for (A, B)
-where
-    A: IntoStream<Item = T>,
-    B: IntoStream<Item = T>,
-{
-    type Item = T;
-    type Stream = Merge2<T, A::IntoStream, B::IntoStream>;
-
-    fn merge(self) -> Self::Stream {
-        Merge2::new((self.0.into_stream(), self.1.into_stream()))
+    // Base condition.
+    ($($F:ident,)*) => {
+        tuple_len!(@inner 0, $($F,)*)
     }
 }
 
-#[derive(Debug)]
-#[pin_project::pin_project]
-pub struct Merge2<T, A, B>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-{
-    streams: (A, B),
-}
+/// Generate the `match` conditions inside the main `poll_next` body. This macro
+/// chooses a random starting stream on each `poll`, making it "fair".
+//
+/// The way this algorithm works is: we generate a random number between 0 and
+/// the number of tuples we have. This number determines which stream we start
+/// with. All other streams are mapped as `r + index`, and after we have the
+/// first stream, we'll sequentially iterate over all other streams. The
+/// starting point of the stream is random, but the iteration order of all other
+/// streams is not.
+///
+// NOTE(yosh): this macro monstrocity is needed so we can increment each `else if` branch with
+// + 1. When RFC 3086 becomes available to us, we can replace this with `${index($F)}` to get
+// the current iteration.
+//
+// # References
+// - https://twitter.com/maybewaffle/status/1588426440835727360
+// - https://twitter.com/Veykril/status/1588231414998335490
+// - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
+macro_rules! gen_conditions {
+    // Generate an `if`-block, and keep iterating.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $pending:expr, $counter:expr, $F:ident, $($rest:ident,)*) => {
+        if $i == ($r + $counter).wrapping_rem($LEN) {
+            match unsafe { Pin::new_unchecked(&mut $this.$F) }.poll_next($cx) {
+                Poll::Ready(Some(value)) => return Poll::Ready(Some(value)),
+                Poll::Ready(None) => continue,
+                Poll::Pending => {
+                    $pending = true;
+                    continue
+                }
+            };
+        }
+        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, $pending, $counter + 1, $($rest,)*)
+    };
 
-impl<T, A, B> Merge2<T, A, B>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-{
-    pub(crate) fn new(streams: (A, B)) -> Self {
-        Self { streams }
+    // End of recursion, nothing to do.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $pending:expr, $counter:expr,) => {};
+
+    // Base condition, setup the depth counter.
+    ($LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $pending:expr, $($F:ident,)*) => {
+        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, $pending, 0, $($F,)*)
     }
 }
 
-impl<T, A, B> Stream for Merge2<T, A, B>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-{
-    type Item = T;
+// TODO: handle none case
+macro_rules! impl_merge_tuple {
+    ($StructName:ident $($F:ident)+) => {
+        impl<T, $($F),*> MergeTrait for ($($F),*)
+        where $(
+            $F: IntoStream<Item = T>,
+        )* {
+            type Item = T;
+            type Stream = $StructName<T, $($F::IntoStream),*>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        const LEN: u32 = 2;
-        const PERMUTATIONS: u32 = permutations(LEN);
-        const DIVISOR: u32 = PERMUTATIONS / LEN;
-        let r = utils::random(PERMUTATIONS);
-        for i in 1..=LEN {
-            if i == r.wrapping_div(DIVISOR) {
-                poll_and_then_return!(&mut this.streams.0, cx)
-            } else if i == (r + 1).wrapping_div(DIVISOR) {
-                poll_and_then_return!(&mut this.streams.1, cx)
-            } else {
-                unreachable!();
+            fn merge(self) -> Self::Stream {
+                let ($($F),*): ($($F),*) = self;
+                $StructName {
+                    done: false,
+                    $($F: $F.into_stream()),*
+                }
             }
         }
-        Poll::Pending
-    }
-}
 
-// TODO: automate this!
-
-impl<T, A, B, C> MergeTrait for (A, B, C)
-where
-    A: IntoStream<Item = T>,
-    B: IntoStream<Item = T>,
-    C: IntoStream<Item = T>,
-{
-    type Item = T;
-    type Stream = Merge3<T, A::IntoStream, B::IntoStream, C::IntoStream>;
-
-    fn merge(self) -> Self::Stream {
-        Merge3::new((
-            self.0.into_stream(),
-            self.1.into_stream(),
-            self.2.into_stream(),
-        ))
-    }
-}
-
-#[derive(Debug)]
-#[pin_project::pin_project]
-pub struct Merge3<T, A, B, C>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-{
-    streams: (A, B, C),
-}
-
-impl<T, A, B, C> Merge3<T, A, B, C>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-{
-    pub(crate) fn new(streams: (A, B, C)) -> Self {
-        Self { streams }
-    }
-}
-
-impl<T, A, B, C> Stream for Merge3<T, A, B, C>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-{
-    type Item = T;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        // SAFETY: we're manually projecting the tuple fields here.
-        let s0 = unsafe { Pin::new_unchecked(&mut this.streams.0) };
-        let s1 = unsafe { Pin::new_unchecked(&mut this.streams.1) };
-        let s2 = unsafe { Pin::new_unchecked(&mut this.streams.2) };
-        const MAX: u32 = permutations(3);
-        match utils::random(MAX) {
-            0 => poll_in_order!(cx, s0, s1, s2),
-            1 => poll_in_order!(cx, s0, s2, s1),
-            2 => poll_in_order!(cx, s1, s0, s2),
-            3 => poll_in_order!(cx, s1, s2, s0),
-            4 => poll_in_order!(cx, s2, s0, s1),
-            5 => poll_in_order!(cx, s2, s1, s0),
-            _ => unreachable!(),
+        #[derive(Debug)]
+        #[pin_project::pin_project]
+        pub struct $StructName<T, $($F),*>
+        where $(
+            $F: Stream<Item = T>,
+        )* {
+            done: bool,
+            $(#[pin] $F: $F,)*
         }
-    }
-}
-impl<T, A, B, C, D> MergeTrait for (A, B, C, D)
-where
-    A: IntoStream<Item = T>,
-    B: IntoStream<Item = T>,
-    C: IntoStream<Item = T>,
-    D: IntoStream<Item = T>,
-{
-    type Item = T;
-    type Stream = Merge4<T, A::IntoStream, B::IntoStream, C::IntoStream, D::IntoStream>;
 
-    fn merge(self) -> Self::Stream {
-        Merge4::new((
-            self.0.into_stream(),
-            self.1.into_stream(),
-            self.2.into_stream(),
-            self.3.into_stream(),
-        ))
-    }
-}
+        impl<T, $($F),*> Stream for $StructName<T, $($F),*>
+        where $(
+            $F: Stream<Item = T>,
+        )* {
+            type Item = T;
 
-#[derive(Debug)]
-#[pin_project::pin_project]
-pub struct Merge4<T, A, B, C, D>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-    D: Stream<Item = T>,
-{
-    streams: (A, B, C, D),
-}
+            fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                let mut this = self.project();
 
-impl<T, A, B, C, D> Merge4<T, A, B, C, D>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-    D: Stream<Item = T>,
-{
-    pub(crate) fn new(streams: (A, B, C, D)) -> Self {
-        Self { streams }
-    }
-}
+                // Return early in case we're polled again after completion.
+                if *this.done {
+                    return Poll::Ready(None);
+                }
 
-impl<T, A, B, C, D> Stream for Merge4<T, A, B, C, D>
-where
-    A: Stream<Item = T>,
-    B: Stream<Item = T>,
-    C: Stream<Item = T>,
-    D: Stream<Item = T>,
-{
-    type Item = T;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        // SAFETY: we're manually projecting the tuple fields here.
-        let s0 = unsafe { Pin::new_unchecked(&mut this.streams.0) };
-        let s1 = unsafe { Pin::new_unchecked(&mut this.streams.1) };
-        let s2 = unsafe { Pin::new_unchecked(&mut this.streams.2) };
-        let s3 = unsafe { Pin::new_unchecked(&mut this.streams.3) };
-        const MAX: u32 = permutations(4);
-        match utils::random(MAX) {
-            // s0 first
-            0 => poll_in_order!(cx, s0, s1, s2, s3),
-            1 => poll_in_order!(cx, s0, s1, s3, s2),
-            2 => poll_in_order!(cx, s0, s2, s1, s3),
-            3 => poll_in_order!(cx, s0, s2, s3, s1),
-            4 => poll_in_order!(cx, s0, s3, s1, s2),
-            5 => poll_in_order!(cx, s0, s3, s2, s1),
-            // s1 first
-            6 => poll_in_order!(cx, s1, s0, s2, s3),
-            7 => poll_in_order!(cx, s1, s0, s3, s2),
-            8 => poll_in_order!(cx, s1, s2, s0, s3),
-            9 => poll_in_order!(cx, s1, s2, s3, s0),
-            10 => poll_in_order!(cx, s1, s3, s0, s2),
-            11 => poll_in_order!(cx, s1, s3, s2, s0),
-            // s2 first
-            12 => poll_in_order!(cx, s2, s0, s1, s3),
-            13 => poll_in_order!(cx, s2, s0, s3, s1),
-            14 => poll_in_order!(cx, s2, s1, s0, s3),
-            15 => poll_in_order!(cx, s2, s1, s3, s0),
-            16 => poll_in_order!(cx, s2, s3, s0, s1),
-            17 => poll_in_order!(cx, s2, s3, s1, s0),
-            // s3 first
-            18 => poll_in_order!(cx, s3, s0, s1, s2),
-            19 => poll_in_order!(cx, s3, s0, s2, s1),
-            20 => poll_in_order!(cx, s3, s1, s0, s2),
-            21 => poll_in_order!(cx, s3, s1, s2, s0),
-            22 => poll_in_order!(cx, s3, s2, s0, s1),
-            23 => poll_in_order!(cx, s3, s2, s1, s0),
-            _ => unreachable!(),
+                const LEN: u32 = tuple_len!($($F,)*);
+                const PERMUTATIONS: u32 = permutations(LEN);
+                let r = utils::random(PERMUTATIONS);
+                let mut pending = false;
+                for i in 0..LEN {
+                    gen_conditions!(LEN, i, r, this, cx, pending, $($F,)*);
+                }
+                if pending {
+                    Poll::Pending
+                } else {
+                    *this.done = true;
+                    Poll::Ready(None)
+                }
+            }
         }
-    }
+    };
 }
+
+impl_merge_tuple! { Merge2 A B }
+impl_merge_tuple! { Merge3 A B C }
+impl_merge_tuple! { Merge4 A B C D }
+impl_merge_tuple! { Merge5 A B C D E }
+impl_merge_tuple! { Merge6 A B C D F G }
+impl_merge_tuple! { Merge7 A B C D F G H }
+impl_merge_tuple! { Merge8 A B C D F G H I }
+impl_merge_tuple! { Merge9 A B C D F G H I J }
+impl_merge_tuple! { Merge10 A B C D F G H I J K }
+impl_merge_tuple! { Merge11 A B C D F G H I J K L }
 
 #[cfg(test)]
 mod tests {
@@ -284,6 +172,25 @@ mod tests {
                 counter += n;
             }
             assert_eq!(counter, 3);
+        })
+    }
+
+    #[test]
+    fn merge_tuple_3() {
+        use crate::stream;
+        use futures_lite::future::block_on;
+
+        block_on(async {
+            let a = stream::once(1);
+            let b = stream::once(2);
+            let c = stream::once(3);
+            let mut s = (a, b, c).merge();
+
+            let mut counter = 0;
+            while let Some(n) = s.next().await {
+                counter += n;
+            }
+            assert_eq!(counter, 6);
         })
     }
 

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -130,16 +130,17 @@ macro_rules! impl_merge_tuple {
     };
 }
 
-impl_merge_tuple! { Merge2 A B }
-impl_merge_tuple! { Merge3 A B C }
-impl_merge_tuple! { Merge4 A B C D }
-impl_merge_tuple! { Merge5 A B C D E }
-impl_merge_tuple! { Merge6 A B C D F G }
-impl_merge_tuple! { Merge7 A B C D F G H }
-impl_merge_tuple! { Merge8 A B C D F G H I }
-impl_merge_tuple! { Merge9 A B C D F G H I J }
-impl_merge_tuple! { Merge10 A B C D F G H I J K }
-impl_merge_tuple! { Merge11 A B C D F G H I J K L }
+impl_merge_tuple! { Merge2  A B }
+impl_merge_tuple! { Merge3  A B C }
+impl_merge_tuple! { Merge4  A B C D }
+impl_merge_tuple! { Merge5  A B C D E }
+impl_merge_tuple! { Merge6  A B C D E F }
+impl_merge_tuple! { Merge7  A B C D E F G }
+impl_merge_tuple! { Merge8  A B C D E F G H }
+impl_merge_tuple! { Merge9  A B C D E F G H I }
+impl_merge_tuple! { Merge10 A B C D E F G H I J }
+impl_merge_tuple! { Merge11 A B C D E F G H I J K }
+impl_merge_tuple! { Merge12 A B C D E F G H I J K L }
 
 #[cfg(test)]
 mod tests {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -6,8 +6,7 @@
 //! ever dropping a single value:
 //!
 //! ```
-//! use futures_concurrency::stream::Merge;
-//! use futures_concurrency::stream;
+//! use futures_concurrency::stream::{self, Merge, Stream};
 //! use futures_lite::future::block_on;
 //!
 //! fn main() {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -6,7 +6,7 @@
 //! ever dropping a single value:
 //!
 //! ```
-//! use futures_concurrency::prelude::*;
+//! use futures_concurrency::stream::Merge;
 //! use futures_concurrency::stream;
 //! use futures_lite::future::block_on;
 //!


### PR DESCRIPTION
Closes https://github.com/yoshuawuyts/futures-concurrency/issues/18

The key insight for this patch was provided by @oli-obk. Rather than iterating through all possible stream permutations, this approach makes it so we have a randomized starting point, and then go through all streams in a fixed order.

Over N-iterations, that still has a "fair" ordering between items. But unlike our prior approach, we can express this entirely using conditionals, which enables auto-generating them. I've added tests for `{2,3,4}`-arity merges, and all seem to pass. Providing a good degree of confidence this patch should continue to work on all existing code. But we now support up to `12`-arity stream merges.

As an added bonus, the generated code should be substantially smaller, which may provide some size reductions as well.

## Notes for stdlib

This code can probably be simplified a bit when we propose it for inclusion in the stdlib. [RFC 3086](https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html) provides more tools for declarative macros, which are not yet available on stable. But we should be able to rely on those within the stdlib.

---

r? @phil-opp - this shouldn't break any code you have, but I'm tagging you to get an extra pair of eyes on this just in case. Thanks!