### PR TITLE
Format debug output

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -30,7 +30,7 @@ where
     Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Join").field("elems", &self.elems).finish()
+        f.debug_list().entries(self.elems.iter()).finish()
     }
 }
 

--- a/src/future/race/array.rs
+++ b/src/future/race/array.rs
@@ -30,7 +30,7 @@ where
     Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Race").field("futs", &self.futs).finish()
+        f.debug_list().entries(self.futs.iter()).finish()
     }
 }
 

--- a/src/future/race/vec.rs
+++ b/src/future/race/vec.rs
@@ -30,7 +30,7 @@ where
     Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Race").field("futs", &self.futs).finish()
+        f.debug_list().entries(self.futs.iter()).finish()
     }
 }
 

--- a/src/future/race_ok/array/mod.rs
+++ b/src/future/race_ok/array/mod.rs
@@ -38,7 +38,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Join").field("elems", &self.elems).finish()
+        f.debug_list().entries(self.elems.iter()).finish()
     }
 }
 

--- a/src/future/race_ok/vec/mod.rs
+++ b/src/future/race_ok/vec/mod.rs
@@ -35,9 +35,7 @@ where
     Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RaceOk")
-            .field("elems", &self.elems)
-            .finish()
+        f.debug_list().entries(self.elems.iter()).finish()
     }
 }
 

--- a/src/future/try_join/array.rs
+++ b/src/future/try_join/array.rs
@@ -32,7 +32,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Join").field("elems", &self.elems).finish()
+        f.debug_list().entries(self.elems.iter()).finish()
     }
 }
 

--- a/src/future/try_join/vec.rs
+++ b/src/future/try_join/vec.rs
@@ -31,9 +31,7 @@ where
     Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TryJoin")
-            .field("elems", &self.elems)
-            .finish()
+        f.debug_list().entries(self.elems.iter()).finish()
     }
 }
 

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -2,6 +2,7 @@ use super::Merge as MergeTrait;
 use crate::stream::IntoStream;
 use crate::utils;
 
+use core::fmt;
 use futures_core::Stream;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -79,7 +80,6 @@ macro_rules! impl_merge_tuple {
         ///
         /// [`merge`]: trait.Merge.html#method.merge
         /// [`Merge`]: trait.Merge.html
-        #[derive(Debug)]
         #[pin_project::pin_project]
         pub struct $StructName<T, $($F),*>
         where $(
@@ -87,6 +87,18 @@ macro_rules! impl_merge_tuple {
         )* {
             done: bool,
             $(#[pin] $F: $F,)*
+        }
+
+        impl<T, $($F),*> std::fmt::Debug for $StructName<T, $($F),*>
+        where $(
+            $F: Stream<Item = T> + fmt::Debug,
+            T: fmt::Debug,
+        )* {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_tuple("Merge")
+                    $(.field(&self.$F))*
+                    .finish()
+            }
         }
 
         impl<T, $($F),*> Stream for $StructName<T, $($F),*>


### PR DESCRIPTION
Closes #33. We probably should still author tests, but we can do that as we modify the debug output starting with e.g. `vec::Join`.