### PR TITLE
More efficient polling in merging Vecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,5 @@ pin-project = "1.0.8"
 
 [dev-dependencies]
 futures-lite = "1.12.0"
+futures = "0.3.25"
 criterion = "0.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,7 @@ use pin_project::pin_project;
 use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("merge 10", |b| b.iter(|| merge_test(black_box(10))));
@@ -21,51 +21,87 @@ criterion_main!(benches);
 
 pub(crate) fn merge_test(max: usize) {
     block_on(async {
-        let counter = Rc::new(RefCell::new(max));
-        let futures: Vec<_> = (1..=max)
-            .rev()
-            .map(|n| Countdown::new(n, counter.clone()))
+        let wakers = Rc::new(RefCell::new(vec![]));
+        let completed = Rc::new(RefCell::new(0));
+        let futures: Vec<_> = (0..max)
+            .map(|n| Countdown::new(n, max, wakers.clone(), completed.clone()))
             .collect();
         let mut s = futures.merge();
 
         let mut counter = 0;
-        while let Some(_) = s.next().await {
+        while s.next().await.is_some() {
             counter += 1;
         }
         assert_eq!(counter, max);
     })
 }
 
+#[derive(Clone, Copy)]
+enum State {
+    Init,
+    Polled,
+    Done,
+}
+
 /// A future which will _eventually_ be ready, but needs to be polled N times before it is.
 #[pin_project]
 struct Countdown {
-    success_count: Rc<RefCell<usize>>,
-    target_count: usize,
-    done: bool,
+    state: State,
+    wakers: Rc<RefCell<Vec<Waker>>>,
+    index: usize,
+    max_count: usize,
+    completed_count: Rc<RefCell<usize>>,
 }
 
 impl Countdown {
-    fn new(count: usize, success_count: Rc<RefCell<usize>>) -> Self {
+    fn new(
+        index: usize,
+        max_count: usize,
+        wakers: Rc<RefCell<Vec<Waker>>>,
+        completed_count: Rc<RefCell<usize>>,
+    ) -> Self {
         Self {
-            success_count,
-            target_count: count,
-            done: false,
+            state: State::Init,
+            wakers,
+            max_count,
+            index,
+            completed_count,
         }
     }
 }
 impl Stream for Countdown {
     type Item = ();
 
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        if *this.done {
-            Poll::Ready(None)
-        } else if *this.success_count.borrow() == *this.target_count {
-            *this.success_count.borrow_mut() -= 1;
-            *this.done = true;
-            Poll::Ready(Some(()))
-        } else {
-            Poll::Pending
+
+        // If we are the last stream to be polled, skip strait to the Polled state.
+        if this.wakers.borrow().len() + 1 == *this.max_count {
+            *this.state = State::Polled;
+        }
+
+        match this.state {
+            State::Init => {
+                // Push our waker onto the stack so we get woken again someday.
+                this.wakers.borrow_mut().push(cx.waker().clone());
+                *this.state = State::Polled;
+                Poll::Pending
+            }
+            State::Polled => {
+                // Wake up the next one
+                let _ = this.wakers.borrow_mut().pop().map(Waker::wake);
+
+                if *this.completed_count.borrow() == *this.index {
+                    *this.state = State::Done;
+                    *this.completed_count.borrow_mut() += 1;
+                    Poll::Ready(Some(()))
+                } else {
+                    // We're not done yet, so schedule another wakeup
+                    this.wakers.borrow_mut().push(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+            State::Done => Poll::Ready(None),
         }
     }
 }

--- a/src/stream/merge/vec.rs
+++ b/src/stream/merge/vec.rs
@@ -5,7 +5,8 @@ use crate::utils::{self, Fuse, RandomGenerator};
 use core::fmt;
 use futures_core::Stream;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
 
 /// A stream that merges multiple streams into a single stream.
 ///
@@ -22,6 +23,57 @@ where
     #[pin]
     streams: Vec<Fuse<S>>,
     rng: RandomGenerator,
+    readiness: Arc<Mutex<Readiness>>,
+    complete: usize,
+}
+
+struct Readiness {
+    count: usize,
+    ready: Vec<bool>, // TODO: Use a bitvector
+}
+
+impl Readiness {
+    /// Returns the old ready state for this id
+    fn set_ready(&mut self, id: usize) -> bool {
+        if !self.ready[id] {
+            self.count += 1;
+            self.ready[id] = true;
+
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Returns whether the task id was previously ready
+    fn clear_ready(&mut self, id: usize) -> bool {
+        if self.ready[id] {
+            self.count -= 1;
+            self.ready[id] = false;
+
+            true
+        } else {
+            false
+        }
+    }
+
+    fn any_ready(&self) -> bool {
+        self.count > 0
+    }
+}
+
+struct StreamWaker {
+    id: usize,
+    readiness: Arc<Mutex<Readiness>>,
+    parent: Waker,
+}
+
+impl Wake for StreamWaker {
+    fn wake(self: std::sync::Arc<Self>) {
+        if !self.readiness.lock().unwrap().set_ready(self.id) {
+            self.parent.wake_by_ref()
+        }
+    }
 }
 
 impl<S> Merge<S>
@@ -29,9 +81,16 @@ where
     S: Stream,
 {
     pub(crate) fn new(streams: Vec<S>) -> Self {
+        let streams: Vec<_> = streams.into_iter().map(Fuse::new).collect();
+        let count = streams.len();
         Self {
-            streams: streams.into_iter().map(Fuse::new).collect(),
+            streams,
             rng: RandomGenerator::new(),
+            readiness: Arc::new(Mutex::new(Readiness {
+                count,
+                ready: vec![true; count],
+            })),
+            complete: 0,
         }
     }
 }
@@ -45,6 +104,14 @@ where
     }
 }
 
+// Plan:
+//
+// 1. Add per-future wakers
+// 2. Add a ready bitvec
+// 3. In poll_next, only poll the futures whose ready bit is set (remember to clear it)
+// 4. ???
+// 5. Profit
+
 impl<S> Stream for Merge<S>
 where
     S: Stream,
@@ -57,18 +124,51 @@ where
         // Iterate over our streams one-by-one. If a stream yields a value,
         // we exit early. By default we'll return `Poll::Ready(None)`, but
         // this changes if we encounter a `Poll::Pending`.
-        let random = this.rng.random(this.streams.len() as u32) as usize;
-        let mut res = Poll::Ready(None);
-        for index in 0..this.streams.len() {
-            let index = (random + index).wrapping_rem(this.streams.len());
-            let stream = utils::get_pin_mut_from_vec(this.streams.as_mut(), index).unwrap();
-            match stream.poll_next(cx) {
-                Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
-                Poll::Ready(None) => continue,
-                Poll::Pending => res = Poll::Pending,
+        let mut index = this.rng.random(this.streams.len() as u32) as usize;
+
+        let mut readiness = this.readiness.lock().unwrap();
+        loop {
+            if !readiness.any_ready() {
+                // Nothing is ready yet
+                return Poll::Pending;
             }
+
+            index = (index + 1).wrapping_rem(this.streams.len());
+
+            if !readiness.clear_ready(index) {
+                continue;
+            }
+
+            // unlock readiness so we don't deadlock when polling
+            drop(readiness);
+
+            let stream = utils::get_pin_mut_from_vec(this.streams.as_mut(), index).unwrap();
+            let waker = Arc::new(StreamWaker {
+                id: index,
+                readiness: this.readiness.clone(),
+                parent: cx.waker().clone(),
+            })
+            .into();
+            let mut cx = Context::from_waker(&waker);
+
+            match stream.poll_next(&mut cx) {
+                Poll::Ready(Some(item)) => {
+                    // Mark ourselves as ready again because we need to poll for the next item.
+                    this.readiness.lock().unwrap().set_ready(index);
+                    return Poll::Ready(Some(item));
+                }
+                Poll::Ready(None) => {
+                    *this.complete += 1;
+                    if *this.complete == this.streams.len() {
+                        return Poll::Ready(None);
+                    }
+                }
+                Poll::Pending => (),
+            }
+
+            // Lock readiness so we can use it again
+            readiness = this.readiness.lock().unwrap();
         }
-        res
     }
 }
 
@@ -86,13 +186,21 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::rc::Rc;
+
     use super::*;
+    use futures::channel::mpsc;
+    use futures::executor::LocalPool;
+    use futures::task::LocalSpawnExt;
+    use futures::SinkExt;
     use futures_lite::future::block_on;
     use futures_lite::prelude::*;
     use futures_lite::stream;
 
     #[test]
-    fn merge_tuple_4() {
+    fn merge_vec_4() {
         block_on(async {
             let a = stream::once(1);
             let b = stream::once(2);
@@ -106,5 +214,137 @@ mod tests {
             }
             assert_eq!(counter, 10);
         })
+    }
+
+    #[test]
+    fn merge_vec_2x2() {
+        block_on(async {
+            let a = stream::repeat(1).take(2);
+            let b = stream::repeat(2).take(2);
+            let mut s = vec![a, b].merge();
+
+            let mut counter = 0;
+            while let Some(n) = s.next().await {
+                counter += n;
+            }
+            assert_eq!(counter, 6);
+        })
+    }
+
+    /// This test case uses channels so we'll have streams that return Pending from time to time.
+    ///
+    /// The purpose of this test is to make sure we have the waking logic working.
+    #[test]
+    fn merge_channels() {
+        use crate::future::join::Join;
+
+        struct LocalChannel<T> {
+            queue: VecDeque<T>,
+            waker: Option<Waker>,
+            closed: bool,
+        }
+
+        struct LocalReceiver<T> {
+            channel: Rc<RefCell<LocalChannel<T>>>,
+        }
+
+        impl<T> Stream for LocalReceiver<T> {
+            type Item = T;
+
+            fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                let mut channel = self.channel.borrow_mut();
+
+                match channel.queue.pop_front() {
+                    Some(item) => Poll::Ready(Some(item)),
+                    None => {
+                        if channel.closed {
+                            Poll::Ready(None)
+                        } else {
+                            channel.waker = Some(cx.waker().clone());
+                            Poll::Pending
+                        }
+                    }
+                }
+            }
+        }
+
+        struct LocalSender<T> {
+            channel: Rc<RefCell<LocalChannel<T>>>,
+        }
+
+        impl<T> LocalSender<T> {
+            fn send(&self, item: T) {
+                let mut channel = self.channel.borrow_mut();
+
+                channel.queue.push_back(item);
+
+                let _ = channel.waker.take().map(Waker::wake);
+            }
+        }
+
+        impl<T> Drop for LocalSender<T> {
+            fn drop(&mut self) {
+                let mut channel = self.channel.borrow_mut();
+                channel.closed = true;
+                let _ = channel.waker.take().map(Waker::wake);
+            }
+        }
+
+        fn local_channel<T>() -> (LocalSender<T>, LocalReceiver<T>) {
+            let channel = Rc::new(RefCell::new(LocalChannel {
+                queue: VecDeque::new(),
+                waker: None,
+                closed: false,
+            }));
+
+            (
+                LocalSender {
+                    channel: channel.clone(),
+                },
+                LocalReceiver { channel },
+            )
+        }
+
+        let mut pool = LocalPool::new();
+
+        let done = Rc::new(RefCell::new(false));
+        let done2 = done.clone();
+
+        pool.spawner()
+            .spawn_local(async move {
+                let (send1, receive1) = local_channel();
+                let (send2, receive2) = local_channel();
+                let (send3, receive3) = local_channel();
+
+                let (count, ()) = (
+                    async {
+                        vec![receive1, receive2, receive3]
+                            .merge()
+                            .fold(0, |a, b| a + b)
+                            .await
+                    },
+                    async {
+                        for i in 1..=4 {
+                            send1.send(i);
+                            send2.send(i);
+                            send3.send(i);
+                        }
+                        drop(send1);
+                        drop(send2);
+                        drop(send3);
+                    },
+                )
+                    .join()
+                    .await;
+
+                assert_eq!(count, 30);
+
+                *done2.borrow_mut() = true;
+            })
+            .unwrap();
+
+        while !*done.borrow() {
+            pool.run_until_stalled()
+        }
     }
 }

--- a/src/stream/merge/vec.rs
+++ b/src/stream/merge/vec.rs
@@ -104,14 +104,6 @@ where
     }
 }
 
-// Plan:
-//
-// 1. Add per-future wakers
-// 2. Add a ready bitvec
-// 3. In poll_next, only poll the futures whose ready bit is set (remember to clear it)
-// 4. ???
-// 5. Profit
-
 impl<S> Stream for Merge<S>
 where
     S: Stream,
@@ -191,10 +183,8 @@ mod tests {
     use std::rc::Rc;
 
     use super::*;
-    use futures::channel::mpsc;
     use futures::executor::LocalPool;
     use futures::task::LocalSpawnExt;
-    use futures::SinkExt;
     use futures_lite::future::block_on;
     use futures_lite::prelude::*;
     use futures_lite::stream;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,12 +10,14 @@ mod maybe_done;
 mod pin;
 mod poll_state;
 mod rng;
+mod waker;
 
 pub(crate) use fuse::Fuse;
 pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::PollState;
 pub(crate) use rng::{random, RandomGenerator};
+pub(crate) use waker::{Readiness, StreamWaker};
 
 #[cfg(test)]
 mod dummy_waker;

--- a/src/utils/waker.rs
+++ b/src/utils/waker.rs
@@ -1,0 +1,82 @@
+use crate::stream::IntoStream;
+use crate::utils::{self, Fuse, RandomGenerator};
+
+use core::fmt;
+use futures_core::Stream;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
+
+#[derive(Debug)]
+pub(crate) struct Readiness {
+    count: usize,
+    ready: Vec<bool>, // TODO: Use a bitvector
+}
+
+impl Readiness {
+    /// Create a new instance of reaciness.
+    pub(crate) fn new(count: usize) -> Self {
+        Self {
+            count,
+            ready: vec![true; count],
+        }
+    }
+
+    /// Returns the old ready state for this id
+    pub(crate) fn set_ready(&mut self, id: usize) -> bool {
+        if !self.ready[id] {
+            self.count += 1;
+            self.ready[id] = true;
+
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Returns whether the task id was previously ready
+    pub(crate) fn clear_ready(&mut self, id: usize) -> bool {
+        if self.ready[id] {
+            self.count -= 1;
+            self.ready[id] = false;
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn any_ready(&self) -> bool {
+        self.count > 0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StreamWaker {
+    id: usize,
+    readiness: Arc<Mutex<Readiness>>,
+    parent_waker: Option<Waker>,
+}
+
+impl StreamWaker {
+    pub(crate) fn new(id: usize, readiness: Arc<Mutex<Readiness>>) -> Self {
+        Self {
+            id,
+            readiness,
+            parent_waker: None,
+        }
+    }
+
+    pub(crate) fn set_parent_waker(&mut self, parent: Waker) {
+        self.parent_waker = Some(parent);
+    }
+}
+
+impl Wake for StreamWaker {
+    fn wake(self: std::sync::Arc<Self>) {
+        if !self.readiness.lock().unwrap().set_ready(self.id) {
+            let parent = self.parent_waker.as_ref().expect("No parent waker was set");
+            parent.wake_by_ref()
+        }
+    }
+}


### PR DESCRIPTION
This changes the implementation of `merge` for `Vec` to keep a vector of readiness information for each substream. This means we can avoid polling streams that we know have not been woken up yet.

This also required significantly re-working the benchmark so wakers actually work right. I've tried to keep the new version true to the spirit of the old version.

Performance is currently a mixed bag, but I think there's room to do better. For small vectors, this change makes things much worse. Performance seems to get better as the vector size increases though.

I suspect in real life vectors will mostly be small, so this change is probably not what we want in the current iteration. I suspect we can improve things quite a bit though, such as by:

1. Fall back on the old behavior for small vectors (we'd need some tuning to know where the right crossover point is).
2. Use a bitvec to store readiness information. This gives us slightly less memory usage, although I doubt that's actually the limiting factor. The bitvec would probably give us a few more percentage points at the high end.
3. Use a `Deque` of indexes for ready tasks instead of a bitvector. This way we don't have to search the whole readiness vector. Again, this will probably help more on the high end and may even hurt on the low end.
4. Reuse wakers. Right now we allocator a new waker each time we poll a stream. This means lots of allocation and deallocation. Instead, we could keep a `Vec<Arc<StreamWaker>>` on the `Merge` struct. This will probably help across the board, but especially on smaller vecs.

Summary of performance changes:
```
merge 10                time:   [1.1286 µs 1.1541 µs 1.1867 µs]                      
                        change: [+80.107% +82.563% +86.171%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe

merge 100               time:   [23.429 µs 23.445 µs 23.463 µs]                       
                        change: [-6.7512% -6.6315% -6.5143%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking merge 1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.7s, enable flat sampling, or reduce sample count to 60.
merge 1000              time:   [1.2730 ms 1.2739 ms 1.2749 ms]                        
                        change: [-45.764% -45.715% -45.667%] (p = 0.00 < 0.05)
                        Performance has improved.
```