### PR TITLE
reuse inline wakers

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,12 +10,14 @@ mod maybe_done;
 mod pin;
 mod poll_state;
 mod rng;
+mod waker;
 
 pub(crate) use fuse::Fuse;
 pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::PollState;
 pub(crate) use rng::{random, RandomGenerator};
+pub(crate) use waker::{Readiness, StreamWaker};
 
 #[cfg(test)]
 mod dummy_waker;

--- a/src/utils/waker.rs
+++ b/src/utils/waker.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Wake, Waker};
 
+#[derive(Debug)]
 pub(crate) struct Readiness {
     count: usize,
     ready: Vec<bool>, // TODO: Use a bitvector
@@ -50,26 +51,32 @@ impl Readiness {
     }
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct StreamWaker {
     id: usize,
     readiness: Arc<Mutex<Readiness>>,
-    parent: Waker,
+    parent_waker: Option<Waker>,
 }
 
 impl StreamWaker {
-    pub(crate) fn new(id: usize, readiness: Arc<Mutex<Readiness>>, parent: Waker) -> Self {
+    pub(crate) fn new(id: usize, readiness: Arc<Mutex<Readiness>>) -> Self {
         Self {
             id,
             readiness,
-            parent,
+            parent_waker: None,
         }
+    }
+
+    pub(crate) fn set_parent_waker(&mut self, parent: Waker) {
+        self.parent_waker = Some(parent);
     }
 }
 
 impl Wake for StreamWaker {
     fn wake(self: std::sync::Arc<Self>) {
         if !self.readiness.lock().unwrap().set_ready(self.id) {
-            self.parent.wake_by_ref()
+            let parent = self.parent_waker.as_ref().expect("No parent waker was set");
+            parent.wake_by_ref()
         }
     }
 }

--- a/src/utils/waker.rs
+++ b/src/utils/waker.rs
@@ -1,0 +1,75 @@
+use crate::stream::IntoStream;
+use crate::utils::{self, Fuse, RandomGenerator};
+
+use core::fmt;
+use futures_core::Stream;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Wake, Waker};
+
+pub(crate) struct Readiness {
+    count: usize,
+    ready: Vec<bool>, // TODO: Use a bitvector
+}
+
+impl Readiness {
+    /// Create a new instance of reaciness.
+    pub(crate) fn new(count: usize) -> Self {
+        Self {
+            count,
+            ready: vec![true; count],
+        }
+    }
+
+    /// Returns the old ready state for this id
+    pub(crate) fn set_ready(&mut self, id: usize) -> bool {
+        if !self.ready[id] {
+            self.count += 1;
+            self.ready[id] = true;
+
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Returns whether the task id was previously ready
+    pub(crate) fn clear_ready(&mut self, id: usize) -> bool {
+        if self.ready[id] {
+            self.count -= 1;
+            self.ready[id] = false;
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn any_ready(&self) -> bool {
+        self.count > 0
+    }
+}
+
+pub(crate) struct StreamWaker {
+    id: usize,
+    readiness: Arc<Mutex<Readiness>>,
+    parent: Waker,
+}
+
+impl StreamWaker {
+    pub(crate) fn new(id: usize, readiness: Arc<Mutex<Readiness>>, parent: Waker) -> Self {
+        Self {
+            id,
+            readiness,
+            parent,
+        }
+    }
+}
+
+impl Wake for StreamWaker {
+    fn wake(self: std::sync::Arc<Self>) {
+        if !self.readiness.lock().unwrap().set_ready(self.id) {
+            self.parent.wake_by_ref()
+        }
+    }
+}


### PR DESCRIPTION
This reuses the waker instances, which should greatly reduce allocations.
# Benchmarks

These benchmarks are compared to the baseline, where we didn't provide inline wakers. It regresses somewhat, but not nearly as much as shown in https://github.com/yoshuawuyts/futures-concurrency/pull/50#issue-1442566344. Furthermore it makes wake times far more _consistent_, which gives me hope that this will become easier to profile, to optimize, and with some moderate effort we'll be able to bring the performance numbers down to where they were before our introduction of this.

## merge 10
![merge-10-Criterion-rs (2)](https://user-images.githubusercontent.com/2467194/201081484-f900e301-2e2b-41c3-830a-b66427daa49e.png)

## merge 100

![merge-100-Criterion-rs](https://user-images.githubusercontent.com/2467194/201081502-cede5b15-5316-457b-9bd6-12d4b4fefd6c.png)

## merge 1000

![merge-1000-Criterion-rs](https://user-images.githubusercontent.com/2467194/201081518-afeb05b9-d2ce-421d-a575-4c3e2ebbdff4.png)
