### PR TITLE
Switch Readiness to use bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "bench"
 harness = false
 
 [dependencies]
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
 pin-project = "1.0.8"
 

--- a/src/utils/waker.rs
+++ b/src/utils/waker.rs
@@ -1,6 +1,8 @@
 use crate::stream::IntoStream;
 use crate::utils::{self, Fuse, RandomGenerator};
 
+use bitvec::bitvec;
+use bitvec::vec::BitVec;
 use core::fmt;
 use futures_core::Stream;
 use std::pin::Pin;
@@ -10,15 +12,15 @@ use std::task::{Context, Poll, Wake, Waker};
 #[derive(Debug)]
 pub(crate) struct Readiness {
     count: usize,
-    ready: Vec<bool>, // TODO: Use a bitvector
+    ready: BitVec,
 }
 
 impl Readiness {
-    /// Create a new instance of reaciness.
+    /// Create a new instance of readiness.
     pub(crate) fn new(count: usize) -> Self {
         Self {
             count,
-            ready: vec![true; count],
+            ready: bitvec![true as usize; count],
         }
     }
 
@@ -26,7 +28,7 @@ impl Readiness {
     pub(crate) fn set_ready(&mut self, id: usize) -> bool {
         if !self.ready[id] {
             self.count += 1;
-            self.ready[id] = true;
+            self.ready.set(id, true);
 
             false
         } else {
@@ -38,7 +40,7 @@ impl Readiness {
     pub(crate) fn clear_ready(&mut self, id: usize) -> bool {
         if self.ready[id] {
             self.count -= 1;
-            self.ready[id] = false;
+            self.ready.set(id, false);
 
             true
         } else {


### PR DESCRIPTION
Use `bitvec::vec::BitVec` instead of `Vec<bool>` on `Readiness`.

Criterion shows performance improvements on all scales, as shown below:

```markdown
merge 10                time:   [1.3549 µs 1.3560 µs 1.3570 µs]
                        change: [-11.014% -10.141% -9.4492%] (p = 0.00 < 0.05)
                        Performance has improved.

merge 100               time:   [28.456 µs 28.565 µs 28.646 µs]
                        change: [-14.309% -13.033% -11.810%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking merge 1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.5s, enable flat sampling, or reduce sample count to 50.
merge 1000              time:   [1.9268 ms 1.9298 ms 1.9320 ms]
                        change: [-9.3127% -7.6118% -6.0476%] (p = 0.00 < 0.05)
                        Performance has improved.
```


> I got mixed results with criterion in some runs, so if someone else can also run the bench suite, I'll more confident