### PR TITLE
fix bench saving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ authors = [
     "Yoshua Wuyts <yoshuawuyts@gmail.com>"
 ]
 
+[lib]
+bench = false
+
 [[bench]]
 name = "bench"
 harness = false


### PR DESCRIPTION
This enables differential benching to work using `critcmp(1)`:

```bash
$ cargo bench "vec::join" -- --save-baseline main
$ git checkout my-branch
$ cargo bench "vec::join" -- --save-baseline patch
$ critcmp main patch -f "vec::join"
```