### PR TITLE
Remove duplication of `gen_conditions`

### DIFF
--- a/src/future/race/tuple.rs
+++ b/src/future/race/tuple.rs
@@ -1,4 +1,5 @@
 use super::Race as RaceTrait;
+use crate::utils;
 
 use core::fmt::{self, Debug};
 use core::future::{Future, IntoFuture};
@@ -6,6 +7,48 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use pin_project::pin_project;
+
+/// Generate the `match` conditions inside the main `poll` body. This macro
+/// chooses a random starting future on each `poll`, making it "fair".
+//
+/// The way this algorithm works is: we generate a random number between 0 and
+/// the number of tuples we have. This number determines which stream we start
+/// with. All other futures are mapped as `r + index`, and after we have the
+/// first future, we'll sequentially iterate over all other futures. The
+/// starting point of the future is random, but the iteration order of all other
+/// futures is not.
+///
+// NOTE(yosh): this macro monstrocity is needed so we can increment each `else if` branch with
+// + 1. When RFC 3086 becomes available to us, we can replace this with `${index($F)}` to get
+// the current iteration.
+//
+// # References
+// - https://twitter.com/maybewaffle/status/1588426440835727360
+// - https://twitter.com/Veykril/status/1588231414998335490
+// - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
+macro_rules! gen_conditions {
+    // Generate an `if`-block, and keep iterating.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr, $F:ident, $($rest:ident,)*) => {
+        if $i == ($r + $counter).wrapping_rem($LEN) {
+            match unsafe { Pin::new_unchecked(&mut $this.$F) }.poll($cx) {
+                Poll::Ready(output) => {
+                    *$this.done = true;
+                    return Poll::Ready(output);
+                }
+                _ => continue,
+            }
+        }
+        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, $counter + 1, $($rest,)*)
+    };
+
+    // End of recursion, nothing to do.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr,) => {};
+
+    // Base condition, setup the depth counter.
+    ($LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $($F:ident,)*) => {
+        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, 0, $($F,)*)
+    }
+}
 
 macro_rules! impl_race_tuple {
     ($StructName:ident $($F:ident)+) => {
@@ -64,13 +107,16 @@ macro_rules! impl_race_tuple {
             fn poll(
                 self: Pin<&mut Self>, cx: &mut Context<'_>
             ) -> Poll<Self::Output> {
-                let this = self.project();
+                let mut this = self.project();
                 assert!(!*this.done, "Futures must not be polled after completing");
 
-                $( if let Poll::Ready(output) = Future::poll(this.$F, cx) {
-                    *this.done = true;
-                    return Poll::Ready(output);
-                })*
+                const LEN: u32 = utils::tuple_len!($($F,)*);
+                const PERMUTATIONS: u32 = utils::permutations(LEN);
+                let r = utils::random(PERMUTATIONS);
+
+                for i in 0..LEN {
+                    gen_conditions!(LEN, i, r, this, cx, $($F,)*);
+                }
 
                 Poll::Pending
             }
@@ -113,16 +159,14 @@ mod test {
         });
     }
 
-    // FIXME: this test will fail once fairness is implemented. "hello" will no
-    // longer be guaranteed.
-    // See: https://github.com/yoshuawuyts/futures-concurrency/issues/44
     #[test]
     fn race_3() {
         futures_lite::future::block_on(async {
             let a = future::pending();
             let b = future::ready("hello");
             let c = future::ready("world");
-            assert_eq!((a, b, c).race().await, "hello");
+            let result = (a, b, c).race().await;
+            assert!(matches!(result, "hello" | "world"));
         });
     }
 }

--- a/src/future/race/tuple.rs
+++ b/src/future/race/tuple.rs
@@ -8,48 +8,6 @@ use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 
-/// Generate the `match` conditions inside the main `poll` body. This macro
-/// chooses a random starting future on each `poll`, making it "fair".
-//
-/// The way this algorithm works is: we generate a random number between 0 and
-/// the number of tuples we have. This number determines which stream we start
-/// with. All other futures are mapped as `r + index`, and after we have the
-/// first future, we'll sequentially iterate over all other futures. The
-/// starting point of the future is random, but the iteration order of all other
-/// futures is not.
-///
-// NOTE(yosh): this macro monstrocity is needed so we can increment each `else if` branch with
-// + 1. When RFC 3086 becomes available to us, we can replace this with `${index($F)}` to get
-// the current iteration.
-//
-// # References
-// - https://twitter.com/maybewaffle/status/1588426440835727360
-// - https://twitter.com/Veykril/status/1588231414998335490
-// - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
-macro_rules! gen_conditions {
-    // Generate an `if`-block, and keep iterating.
-    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr, $F:ident, $($rest:ident,)*) => {
-        if $i == ($r + $counter).wrapping_rem($LEN) {
-            match unsafe { Pin::new_unchecked(&mut $this.$F) }.poll($cx) {
-                Poll::Ready(output) => {
-                    *$this.done = true;
-                    return Poll::Ready(output);
-                }
-                _ => continue,
-            }
-        }
-        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, $counter + 1, $($rest,)*)
-    };
-
-    // End of recursion, nothing to do.
-    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr,) => {};
-
-    // Base condition, setup the depth counter.
-    ($LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $($F:ident,)*) => {
-        gen_conditions!(@inner $LEN, $i, $r, $this, $cx, 0, $($F,)*)
-    }
-}
-
 macro_rules! impl_race_tuple {
     ($StructName:ident $($F:ident)+) => {
         /// Wait for the first future to complete.
@@ -115,7 +73,13 @@ macro_rules! impl_race_tuple {
                 let r = utils::random(PERMUTATIONS);
 
                 for i in 0..LEN {
-                    gen_conditions!(LEN, i, r, this, cx, $($F,)*);
+                    utils::gen_conditions!(LEN, i, r, this, cx, poll, {
+                        Poll::Ready(output) => {
+                            *this.done = true;
+                            return Poll::Ready(output);
+                        },
+                        _ => continue,
+                    }, $($F,)*);
                 }
 
                 Poll::Pending

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,6 +10,7 @@ mod maybe_done;
 mod pin;
 mod poll_state;
 mod rng;
+mod tuple;
 mod waker;
 
 pub(crate) use fuse::Fuse;
@@ -17,6 +18,7 @@ pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::PollState;
 pub(crate) use rng::{random, RandomGenerator};
+pub(crate) use tuple::{permutations, tuple_len};
 pub(crate) use waker::{Readiness, StreamWaker};
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::PollState;
 pub(crate) use rng::{random, RandomGenerator};
-pub(crate) use tuple::{permutations, tuple_len};
+pub(crate) use tuple::{gen_conditions, permutations, tuple_len};
 pub(crate) use waker::{Readiness, StreamWaker};
 
 #[cfg(test)]

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -1,0 +1,19 @@
+/// Compute the number of permutations for a number
+/// during compilation.
+pub(crate) const fn permutations(mut num: u32) -> u32 {
+    let mut total = 1;
+    loop {
+        total *= num;
+        num -= 1;
+        if num == 0 {
+            break total;
+        }
+    }
+}
+
+/// Calculate the number of tuples currently being operated on.
+macro_rules! tuple_len {
+    (@count_one $F:ident) => (1);
+    ($($F:ident,)*) => (0 $(+ crate::utils::tuple_len!(@count_one $F))*);
+}
+pub(crate) use tuple_len;

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -17,3 +17,41 @@ macro_rules! tuple_len {
     ($($F:ident,)*) => (0 $(+ crate::utils::tuple_len!(@count_one $F))*);
 }
 pub(crate) use tuple_len;
+
+/// Generate the `match` conditions inside the main polling body. This macro
+/// chooses a random starting point on each call to the given method, making
+/// it "fair".
+///
+/// The way this algorithm works is: we generate a random number between 0 and
+/// the lenght of the tuple we have. This number determines which element we
+/// start with. All other cases are mapped as `r + index`, and after we have the
+/// first one, we'll sequentially iterate over all others. The starting point of
+/// the stream is random, but the iteration order of all others is not.
+// NOTE(yosh): this macro monstrocity is needed so we can increment each `else
+// if` branch with + 1. When RFC 3086 becomes available to us, we can replace
+// this with `${index($F)}` to get the current iteration.
+//
+// # References
+// - https://twitter.com/maybewaffle/status/1588426440835727360
+// - https://twitter.com/Veykril/status/1588231414998335490
+// - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
+macro_rules! gen_conditions {
+    // Generate an if-block, and keep iterating.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr, $method:ident, {$($arms:pat => $foo:expr,)*}, $F:ident, $($rest:ident,)*) => {
+        if $i == ($r + $counter).wrapping_rem($LEN) {
+            match unsafe { Pin::new_unchecked(&mut $this.$F) }.$method($cx) {
+                $($arms => $foo,)*
+            }
+        }
+        crate::utils::gen_conditions!(@inner $LEN, $i, $r, $this, $cx, $counter + 1, $method, {$($arms => $foo,)*}, $($rest,)*)
+    };
+
+    // End of recursion, nothing to do.
+    (@inner $LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $counter:expr, $method:ident, {$($arms:pat => $foo:expr,)*},) => {};
+
+    // Base condition, setup the depth counter.
+    ($LEN:expr, $i:expr, $r:expr, $this:expr, $cx:expr, $method:ident, {$($arms:pat => $foo:expr,)*}, $($F:ident,)*) => {
+        crate::utils::gen_conditions!(@inner $LEN, $i, $r, $this, $cx, 0, $method, {$($arms => $foo,)*}, $($F,)*)
+    }
+}
+pub(crate) use gen_conditions;


### PR DESCRIPTION
This removes the macro duplication from #58.

We add two new parameters to the macro: the method to be called (either `poll` or `poll_next`), and the match arms.

One nice thing is that by receiving the match arms, we can now reference some things that before were passed as arguments (such as `pending`).