### PR TITLE
Use `array::from_fn` to safely create output array of `MaybeUninit`

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -53,14 +53,12 @@ where
         }
 
         if all_done {
+            use core::array;
             use core::mem::MaybeUninit;
 
             // Create the result array based on the indices
-            let mut out: [MaybeUninit<Fut::Output>; N] = {
-                // inlined version of unstable `MaybeUninit::uninit_array()`
-                // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
-                unsafe { MaybeUninit::<[MaybeUninit<_>; N]>::uninit().assume_init() }
-            };
+            // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
+            let mut out: [_; N] = array::from_fn(|_| MaybeUninit::uninit());
 
             // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
             #[allow(clippy::needless_range_loop)]

--- a/src/future/race_ok/array/mod.rs
+++ b/src/future/race_ok/array/mod.rs
@@ -66,14 +66,12 @@ where
         }
 
         if all_done {
+            use core::array;
             use core::mem::MaybeUninit;
 
             // Create the result array based on the indices
-            let mut out: [MaybeUninit<E>; N] = {
-                // inlined version of unstable `MaybeUninit::uninit_array()`
-                // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
-                unsafe { MaybeUninit::<[MaybeUninit<_>; N]>::uninit().assume_init() }
-            };
+            // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
+            let mut out: [_; N] = array::from_fn(|_| MaybeUninit::uninit());
 
             // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
             #[allow(clippy::needless_range_loop)]

--- a/src/future/try_join/array.rs
+++ b/src/future/try_join/array.rs
@@ -60,14 +60,12 @@ where
         }
 
         if all_done {
+            use core::array;
             use core::mem::MaybeUninit;
 
             // Create the result array based on the indices
-            let mut out: [MaybeUninit<T>; N] = {
-                // inlined version of unstable `MaybeUninit::uninit_array()`
-                // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
-                unsafe { MaybeUninit::<[MaybeUninit<_>; N]>::uninit().assume_init() }
-            };
+            // TODO: replace with `MaybeUninit::uninit_array()` when it becomes stable
+            let mut out: [_; N] = array::from_fn(|_| MaybeUninit::uninit());
 
             // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
             #[allow(clippy::needless_range_loop)]


### PR DESCRIPTION
There're no performance impacts, just remove some unsafe using `array::from_fn`