### PR TITLE
inline random number generator

### DIFF
--- a/src/future/race/tuple.rs
+++ b/src/future/race/tuple.rs
@@ -25,6 +25,7 @@ macro_rules! impl_race_tuple {
             $F: Future<Output = T>,
         )* {
             done: bool,
+            rng: utils::RandomGenerator,
             $(#[pin] $F: $F,)*
         }
 
@@ -51,6 +52,7 @@ macro_rules! impl_race_tuple {
                 let ($($F,)*): ($($F,)*) = self;
                 $StructName {
                     done: false,
+                    rng: utils::RandomGenerator::new(),
                     $($F: $F.into_future()),*
                 }
             }
@@ -70,7 +72,7 @@ macro_rules! impl_race_tuple {
 
                 const LEN: u32 = utils::tuple_len!($($F,)*);
                 const PERMUTATIONS: u32 = utils::permutations(LEN);
-                let r = utils::random(PERMUTATIONS);
+                let r = this.rng.generate(PERMUTATIONS);
 
                 for i in 0..LEN {
                     utils::gen_conditions!(LEN, i, r, this, cx, poll, {

--- a/src/stream/merge/array.rs
+++ b/src/stream/merge/array.rs
@@ -21,6 +21,7 @@ where
 {
     #[pin]
     streams: [Fuse<S>; N],
+    rng: utils::RandomGenerator,
 }
 
 impl<S, const N: usize> Merge<S, N>
@@ -30,6 +31,7 @@ where
     pub(crate) fn new(streams: [S; N]) -> Self {
         Self {
             streams: streams.map(Fuse::new),
+            rng: utils::RandomGenerator::new(),
         }
     }
 }
@@ -66,7 +68,7 @@ where
                 res
             })
         };
-        arr.sort_by_cached_key(|_| utils::random(1000));
+        arr.sort_by_cached_key(|_| this.rng.generate(1000));
 
         // Iterate over our streams one-by-one. If a stream yields a value,
         // we exit early. By default we'll return `Poll::Ready(None)`, but

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -19,7 +19,7 @@ macro_rules! impl_merge_tuple {
         /// [`Merge`]: trait.Merge.html
         #[pin_project::pin_project]
         pub struct $StructName {
-            _sealed: (),
+            rng: utils::RandomGenerator,
         }
 
         impl fmt::Debug for $StructName {
@@ -42,7 +42,7 @@ macro_rules! impl_merge_tuple {
 
             fn merge(self) -> Self::Stream {
                 $StructName {
-                    _sealed: (),
+                    rng: utils::RandomGenerator::new(),
                 }
             }
         }
@@ -62,6 +62,7 @@ macro_rules! impl_merge_tuple {
         )* {
             done: bool,
             $(#[pin] $F: $F,)*
+            rng: utils::RandomGenerator,
         }
 
         impl<T, $($F),*> fmt::Debug for $StructName<T, $($F),*>
@@ -92,7 +93,7 @@ macro_rules! impl_merge_tuple {
 
                 const LEN: u32 = utils::tuple_len!($($F,)*);
                 const PERMUTATIONS: u32 = utils::permutations(LEN);
-                let r = utils::random(PERMUTATIONS);
+                let r = this.rng.generate(PERMUTATIONS);
                 let mut pending = false;
                 for i in 0..LEN {
                     utils::gen_conditions!(LEN, i, r, this, cx, poll_next, {
@@ -124,6 +125,7 @@ macro_rules! impl_merge_tuple {
                 let ($($F,)*): ($($F,)*) = self;
                 $StructName {
                     done: false,
+                    rng: utils::RandomGenerator::new(),
                     $($F: $F.into_stream()),*
                 }
             }

--- a/src/stream/merge/vec.rs
+++ b/src/stream/merge/vec.rs
@@ -69,7 +69,7 @@ where
         // Iterate over our streams one-by-one. If a stream yields a value,
         // we exit early. By default we'll return `Poll::Ready(None)`, but
         // this changes if we encounter a `Poll::Pending`.
-        let mut index = this.rng.random(this.streams.len() as u32) as usize;
+        let mut index = this.rng.generate(this.streams.len() as u32) as usize;
 
         let mut readiness = this.readiness.lock().unwrap();
         loop {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use fuse::Fuse;
 pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::PollState;
-pub(crate) use rng::{random, RandomGenerator};
+pub(crate) use rng::RandomGenerator;
 pub(crate) use tuple::{gen_conditions, permutations, tuple_len};
 pub(crate) use waker::{Readiness, StreamWaker};
 

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -1,36 +1,4 @@
-use std::cell::Cell;
 use std::num::Wrapping;
-use std::thread_local;
-
-/// Generates a random number in `0..n`.
-pub(crate) fn random(n: u32) -> u32 {
-    thread_local! {
-        static RNG: Cell<Wrapping<u32>> = {
-            // Take the address of a local value as seed.
-            let mut x = 0i32;
-            let r = &mut x;
-            let addr = r as *mut i32 as usize;
-            Cell::new(Wrapping(addr as u32))
-        }
-    }
-
-    RNG.with(|rng| {
-        // This is the 32-bit variant of Xorshift.
-        //
-        // Source: https://en.wikipedia.org/wiki/Xorshift
-        let mut x = rng.get();
-        x ^= x << 13;
-        x ^= x >> 17;
-        x ^= x << 5;
-        rng.set(x);
-
-        // This is a fast alternative to `x % n`.
-        //
-        // Author: Daniel Lemire
-        // Source: https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-        ((u64::from(x.0)).wrapping_mul(u64::from(n)) >> 32) as u32
-    })
-}
 
 /// Generates a random number in `0..n`.
 pub(crate) struct RandomGenerator(Wrapping<u32>);
@@ -43,7 +11,7 @@ impl RandomGenerator {
         let addr = r as *mut i32 as usize;
         Self(Wrapping(addr as u32))
     }
-    pub(crate) fn random(&mut self, n: u32) -> u32 {
+    pub(crate) fn generate(&mut self, n: u32) -> u32 {
         // This is the 32-bit variant of Xorshift.
         //
         // Source: https://en.wikipedia.org/wiki/Xorshift


### PR DESCRIPTION
Inlines the random number generator. Closes #47.

## Benchmarks
This improves performance across the board, except for `tuple::merge`, but that's already on a nanosecond scale and is therefor negligable. The biggest improvement is for `array::merge` on smaller sizes, where we see a jump from 4.2 microseconds to 2.6 microseconds.

```text
❯ critcmp inline-rng main  -f merge
group                inline-rng                              main
-----                ----------                              ----
array::merge 10      1.00      2.6±0.18µs        ? ?/sec     1.61      4.2±0.26µs        ? ?/sec
array::merge 100     1.00   355.7±28.52µs        ? ?/sec     1.06   376.3±25.42µs        ? ?/sec
array::merge 1000    1.00     40.0±1.52ms        ? ?/sec     1.00     40.0±1.72ms        ? ?/sec
tuple::merge 10      1.07  1801.0±168.09ns       ? ?/sec     1.00  1683.0±169.57ns       ? ?/sec
vec::merge 10        1.00      4.2±0.30µs        ? ?/sec     1.26      5.3±0.58µs        ? ?/sec
vec::merge 100       1.00     61.5±3.68µs        ? ?/sec     1.11     68.5±7.33µs        ? ?/sec
vec::merge 1000      1.00      2.2±0.13ms        ? ?/sec     1.01      2.2±0.09ms        ? ?/sec
```