### PR TITLE
Remove `MaybeDone` from `tuple::join`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ harness = false
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
-paste = "1.0.9"
 pin-project = "1.0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ harness = false
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
+paste = "1.0.9"
 pin-project = "1.0.8"
 
 [dev-dependencies]

--- a/src/utils/poll_state.rs
+++ b/src/utils/poll_state.rs
@@ -69,6 +69,19 @@ pub(crate) enum PollStates {
     Boxed(Box<[PollState]>),
 }
 
+impl core::fmt::Debug for PollStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inline(len, states) => f
+                // .debug_tuple("Inline")
+                .debug_list()
+                .entries(&states[..(*len as usize)])
+                .finish(),
+            Self::Boxed(states) => f.debug_list().entries(&**states).finish(),
+        }
+    }
+}
+
 impl PollStates {
     pub(crate) fn new(len: usize) -> Self {
         assert!(MAX_INLINE_ENTRIES <= u8::MAX as usize);

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -1,6 +1,10 @@
 /// Compute the number of permutations for a number
 /// during compilation.
 pub(crate) const fn permutations(mut num: u32) -> u32 {
+    if num == 0 {
+        return 0;
+    }
+
     let mut total = 1;
     loop {
         total *= num;


### PR DESCRIPTION
Ref #22 

Remove the need for `MaybeDone` on `tuple::join` by creating for each future three fields: the Future itself; its result; its state.

I had to add a dependency on `paste` to create the `$F_fields`.

Bench:
```text
>> critcmp main patch -f tuple::join
group             main                                   patch
-----             ----                                   -----
tuple::join 10    1.00    232.6±9.13ns        ? ?/sec    1.14    266.0±3.09ns        ? ?/sec
```