### PR TITLE
Avoid allocation for small length in PollState tracking

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,7 @@ mod wakers;
 pub(crate) use fuse::Fuse;
 pub(crate) use maybe_done::MaybeDone;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
-pub(crate) use poll_state::PollState;
+pub(crate) use poll_state::{PollState, PollStates};
 pub(crate) use rng::RandomGenerator;
 pub(crate) use tuple::{gen_conditions, permutations, tuple_len};
 pub(crate) use wakers::{InlineWaker, Readiness, WakerList};

--- a/src/utils/poll_state.rs
+++ b/src/utils/poll_state.rs
@@ -1,5 +1,8 @@
+use std::ops::{Deref, DerefMut};
+
 /// Enumerate the current poll state.
 #[derive(Debug, Clone, Copy, Default)]
+#[repr(u8)]
 pub(crate) enum PollState {
     /// Polling the underlying future.
     #[default]
@@ -35,5 +38,92 @@ impl PollState {
     #[must_use]
     pub(crate) fn is_consumed(&self) -> bool {
         matches!(self, Self::Consumed)
+    }
+}
+
+/// The maximum number of entries that `PollStates` can store without
+/// dynamic memory allocation.
+///
+/// The `Boxed` variant is the minimum size the data structure can have.
+/// It consists of a boxed slice (=2 usizes) and space for the enum
+/// tag (another usize because of padding), so 3 usizes.
+/// The inline variant then consists of `3 * size_of(usize) - 2` entries.
+/// Each entry is a byte and we subtract one byte for a length field,
+/// and another byte for the enum tag.
+///
+/// ```txt
+///                                 Boxed
+///                                 vvvvv
+/// tag
+///  | <-------padding----> <--- Box<[T]>::len ---> <--- Box<[T]>::ptr --->
+/// 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23  <bytes
+///  |  | <------------------- entries ----------------------------------->
+/// tag |
+///    len                          ^^^^^
+///                                 Inline
+/// ```
+const MAX_INLINE_ENTRIES: usize = std::mem::size_of::<usize>() * 3 - 2;
+
+pub(crate) enum PollStates {
+    Inline(u8, [PollState; MAX_INLINE_ENTRIES]),
+    Boxed(Box<[PollState]>),
+}
+
+impl PollStates {
+    pub(crate) fn new(len: usize) -> Self {
+        assert!(MAX_INLINE_ENTRIES <= u8::MAX as usize);
+
+        if len <= MAX_INLINE_ENTRIES {
+            Self::Inline(len as u8, Default::default())
+        } else {
+            // Make sure that we don't reallocate the vec's memory
+            // during `Vec::into_boxed_slice()`.
+            let mut states = Vec::new();
+            debug_assert_eq!(states.capacity(), 0);
+            states.reserve_exact(len);
+            debug_assert_eq!(states.capacity(), len);
+            states.resize(len, PollState::default());
+            debug_assert_eq!(states.capacity(), len);
+            Self::Boxed(states.into_boxed_slice())
+        }
+    }
+}
+
+impl Deref for PollStates {
+    type Target = [PollState];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            PollStates::Inline(len, states) => &states[..*len as usize],
+            Self::Boxed(states) => &states[..],
+        }
+    }
+}
+
+impl DerefMut for PollStates {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            PollStates::Inline(len, states) => &mut states[..*len as usize],
+            Self::Boxed(states) => &mut states[..],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PollStates, MAX_INLINE_ENTRIES};
+
+    #[test]
+    fn type_size() {
+        assert_eq!(
+            std::mem::size_of::<PollStates>(),
+            std::mem::size_of::<usize>() * 3
+        );
+    }
+
+    #[test]
+    fn boxed_does_not_allocate_twice() {
+        // Make sure the debug_assertions in PollStates::new() don't fail.
+        let _ = PollStates::new(MAX_INLINE_ENTRIES + 10);
     }
 }


### PR DESCRIPTION
This is a simpler version of https://github.com/yoshuawuyts/futures-concurrency/pull/48.

