### PR TITLE
Hide PollState variants

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -1,5 +1,5 @@
 use super::Join as JoinTrait;
-use crate::utils::{self, PollArray, PollState};
+use crate::utils::{self, PollArray};
 
 use core::array;
 use core::fmt;
@@ -90,7 +90,7 @@ where
             if this.state[i].is_pending() {
                 if let Poll::Ready(value) = fut.poll(cx) {
                     this.items[i] = MaybeUninit::new(value);
-                    this.state[i] = PollState::Ready;
+                    this.state[i].set_ready();
                     *this.pending -= 1;
                 }
             }
@@ -105,7 +105,7 @@ where
                     state.is_ready(),
                     "Future should have reached a `Ready` state"
                 );
-                *state = PollState::Consumed;
+                state.set_consumed();
             }
 
             let mut items = array::from_fn(|_| MaybeUninit::uninit());

--- a/src/future/join/vec.rs
+++ b/src/future/join/vec.rs
@@ -1,5 +1,5 @@
 use super::Join as JoinTrait;
-use crate::utils::{iter_pin_mut_vec, PollState, PollVec};
+use crate::utils::{iter_pin_mut_vec, PollVec};
 
 use core::fmt;
 use core::future::{Future, IntoFuture};
@@ -91,7 +91,7 @@ where
             if states[i].is_pending() {
                 if let Poll::Ready(value) = fut.poll(cx) {
                     this.items[i] = MaybeUninit::new(value);
-                    states[i] = PollState::Ready;
+                    states[i].set_ready();
                     *this.pending -= 1;
                 }
             }
@@ -106,7 +106,7 @@ where
                     state.is_ready(),
                     "Future should have reached a `Ready` state"
                 );
-                *state = PollState::Consumed;
+                state.set_consumed();
             });
 
             // SAFETY: we've checked with the state that all of our outputs have been

--- a/src/stream/merge/array.rs
+++ b/src/stream/merge/array.rs
@@ -1,6 +1,6 @@
 use super::Merge as MergeTrait;
 use crate::stream::IntoStream;
-use crate::utils::{self, PollArray, PollState, RandomGenerator, WakerArray};
+use crate::utils::{self, PollArray, RandomGenerator, WakerArray};
 
 use core::fmt;
 use futures_core::Stream;
@@ -93,7 +93,7 @@ where
                 }
                 Poll::Ready(None) => {
                     *this.complete += 1;
-                    this.state[index] = PollState::Consumed;
+                    this.state[index].set_consumed();
                     if *this.complete == this.streams.len() {
                         return Poll::Ready(None);
                     }

--- a/src/stream/merge/vec.rs
+++ b/src/stream/merge/vec.rs
@@ -1,6 +1,6 @@
 use super::Merge as MergeTrait;
 use crate::stream::IntoStream;
-use crate::utils::{self, PollState, PollVec, RandomGenerator, WakerVec};
+use crate::utils::{self, PollVec, RandomGenerator, WakerVec};
 
 use core::fmt;
 use futures_core::Stream;
@@ -94,7 +94,7 @@ where
                 }
                 Poll::Ready(None) => {
                     *this.complete += 1;
-                    this.state[index] = PollState::Consumed;
+                    this.state[index].set_consumed();
                     if *this.complete == this.streams.len() {
                         return Poll::Ready(None);
                     }

--- a/src/stream/zip/array.rs
+++ b/src/stream/zip/array.rs
@@ -89,14 +89,14 @@ where
             match stream.poll_next(&mut cx) {
                 Poll::Ready(Some(item)) => {
                     this.output[index] = MaybeUninit::new(item);
-                    this.state[index] = PollState::Ready;
+                    this.state[index].set_ready();
 
                     let all_ready = this.state.iter().all(|state| state.is_ready());
                     if all_ready {
                         // Reset the future's state.
                         readiness = this.wakers.readiness().lock().unwrap();
                         readiness.set_all_ready();
-                        this.state.fill(PollState::Pending);
+                        this.state.fill_with(PollState::default);
 
                         // Take the output
                         //

--- a/src/stream/zip/vec.rs
+++ b/src/stream/zip/vec.rs
@@ -91,14 +91,14 @@ where
             match stream.poll_next(&mut cx) {
                 Poll::Ready(Some(item)) => {
                     this.output[index] = MaybeUninit::new(item);
-                    this.state[index] = PollState::Ready;
+                    this.state[index].set_ready();
 
                     let all_ready = this.state.iter().all(|state| state.is_ready());
                     if all_ready {
                         // Reset the future's state.
                         readiness = this.wakers.readiness().lock().unwrap();
                         readiness.set_all_ready();
-                        this.state.fill(PollState::Pending);
+                        this.state.fill_with(PollState::default);
 
                         // Take the output
                         //

--- a/src/utils/poll_state/poll_state.rs
+++ b/src/utils/poll_state/poll_state.rs
@@ -25,11 +25,19 @@ impl PollState {
 
     /// Returns `true` if the poll state is [`Ready`].
     ///
-    /// [`Done`]: PollState::Ready
+    /// [`Ready`]: PollState::Ready
     #[must_use]
     #[inline]
     pub(crate) fn is_ready(&self) -> bool {
         matches!(self, Self::Ready)
+    }
+
+    /// Sets the poll state to [`Ready`]
+    ///
+    /// [`Ready`]: PollState::Ready
+    #[inline]
+    pub(crate) fn set_ready(&mut self) {
+        *self = PollState::Ready;
     }
 
     /// Returns `true` if the poll state is [`Consumed`].
@@ -39,5 +47,13 @@ impl PollState {
     #[inline]
     pub(crate) fn is_consumed(&self) -> bool {
         matches!(self, Self::Consumed)
+    }
+
+    /// Sets the poll state to [`Consumed`]
+    ///
+    /// [`Consumed`]: PollState::Consumed
+    #[inline]
+    pub(crate) fn set_consumed(&mut self) {
+        *self = PollState::Consumed;
     }
 }


### PR DESCRIPTION
Closes #88 

I also "hid" `PollState::Ready` behind a `set_ready`. Now no one outside `utils/poll_state/poll_state.rs` references the variants by name.