### PR TITLE
Fix typos

### DIFF
--- a/src/future/race_ok/vec/error.rs
+++ b/src/future/race_ok/vec/error.rs
@@ -35,7 +35,7 @@ impl<E: Error> fmt::Debug for AggregateError<E> {
 
 impl<E: Error> fmt::Display for AggregateError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} errors occured", self.inner.len())
+        write!(f, "{} errors occurred", self.inner.len())
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -43,7 +43,7 @@
 //! `stream::once`, futures can be converted into async iterators and then used
 //! with any of the iterator concurrency methods. This enables operations such
 //! as `stream::Merge` to be used to execute sets of futures concurrently, but
-//! obtain the invididual future's outputs as soon as they're available.
+//! obtain the individual future's outputs as soon as they're available.
 //!
 //! See the [future concurrency][crate::future#concurrency] documentation for
 //! more on futures concurrency.

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -16,11 +16,11 @@ pub(crate) const fn permutations(mut num: u32) -> u32 {
 /// it "fair".
 ///
 /// The way this algorithm works is: we generate a random number between 0 and
-/// the lenght of the tuple we have. This number determines which element we
+/// the length of the tuple we have. This number determines which element we
 /// start with. All other cases are mapped as `r + index`, and after we have the
 /// first one, we'll sequentially iterate over all others. The starting point of
 /// the stream is random, but the iteration order of all others is not.
-// NOTE(yosh): this macro monstrocity is needed so we can increment each `else
+// NOTE(yosh): this macro monstrosity is needed so we can increment each `else
 // if` branch with + 1. When RFC 3086 becomes available to us, we can replace
 // this with `${index($F)}` to get the current iteration.
 //


### PR DESCRIPTION
Found via `typos --format brief`