### PR TITLE
Fix a possible memory leak on the impl of `Join` for tuples

### DIFF
--- a/src/utils/poll_state/array.rs
+++ b/src/utils/poll_state/array.rs
@@ -12,6 +12,17 @@ impl<const N: usize> PollArray<N> {
             state: [PollState::default(); N],
         }
     }
+
+    #[inline]
+    pub(crate) fn set_all_completed(&mut self) {
+        self.iter_mut().for_each(|state| {
+            debug_assert!(
+                state.is_ready(),
+                "Future should have reached a `Ready` state"
+            );
+            state.set_consumed();
+        })
+    }
 }
 
 impl<const N: usize> Deref for PollArray<N> {


### PR DESCRIPTION
If we don't poll `JoinX` to completion, we may leak data.