### PR TITLE
Remove unecessary `core::fmt::Debug` requirements

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -65,7 +65,6 @@ where
 impl<Fut, const N: usize> fmt::Debug for Join<Fut, N>
 where
     Fut: Future + fmt::Debug,
-    Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.state.iter()).finish()

--- a/src/future/join/tuple.rs
+++ b/src/future/join/tuple.rs
@@ -125,10 +125,9 @@ macro_rules! impl_join_tuple {
         }
 
         impl<$($F),+> Debug for $StructName<$($F),+>
-        where $(
-            $F: Future + Debug,
-            $F::Output: Debug,
-        )+ {
+        where
+            $( $F: Future + Debug, )+
+        {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple("Join")
                     $(.field(&self.futures.$F))+

--- a/src/future/join/vec.rs
+++ b/src/future/join/vec.rs
@@ -66,7 +66,6 @@ where
 impl<Fut> fmt::Debug for Join<Fut>
 where
     Fut: Future + fmt::Debug,
-    Fut::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.state.iter()).finish()

--- a/src/future/race/tuple.rs
+++ b/src/future/race/tuple.rs
@@ -32,7 +32,6 @@ macro_rules! impl_race_tuple {
         impl<T, $($F),*> Debug for $StructName<T, $($F),*>
         where $(
             $F: Future<Output = T> + Debug,
-            T: Debug,
         )* {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple("Race")

--- a/src/future/race_ok/array/mod.rs
+++ b/src/future/race_ok/array/mod.rs
@@ -26,7 +26,6 @@ pub use error::AggregateError;
 #[pin_project]
 pub struct RaceOk<Fut, T, E, const N: usize>
 where
-    T: fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
 {
     #[pin]
@@ -39,7 +38,6 @@ impl<Fut, T, E, const N: usize> fmt::Debug for RaceOk<Fut, T, E, N>
 where
     Fut: Future<Output = Result<T, E>> + fmt::Debug,
     Fut::Output: fmt::Debug,
-    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.futures.iter()).finish()
@@ -48,9 +46,7 @@ where
 
 impl<Fut, T, E, const N: usize> Future for RaceOk<Fut, T, E, N>
 where
-    T: fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
-    E: fmt::Debug,
 {
     type Output = Result<T, AggregateError<E, N>>;
 
@@ -88,9 +84,7 @@ where
 
 impl<Fut, T, E, const N: usize> RaceOkTrait for [Fut; N]
 where
-    T: fmt::Debug,
     Fut: IntoFuture<Output = Result<T, E>>,
-    E: fmt::Debug,
 {
     type Output = T;
     type Error = AggregateError<E, N>;

--- a/src/future/race_ok/tuple/mod.rs
+++ b/src/future/race_ok/tuple/mod.rs
@@ -41,7 +41,6 @@ macro_rules! impl_race_ok_tuple {
         impl<T, ERR, $($F),*> fmt::Debug for $StructName<T, ERR, $($F),*>
         where
             $( $F: Future<Output = Result<T, ERR>> + fmt::Debug, )*
-            T: fmt::Debug,
             ERR: fmt::Debug,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/future/race_ok/vec/mod.rs
+++ b/src/future/race_ok/vec/mod.rs
@@ -53,15 +53,20 @@ where
         for mut elem in iter_pin_mut(self.elems.as_mut()) {
             if elem.as_mut().poll(cx).is_pending() {
                 all_done = false
-            } else if let Some(Ok(_)) = elem.as_ref().output() {
-                return Poll::Ready(Ok(elem.take().unwrap().unwrap()));
+            } else if let Some(output) = elem.take_ok() {
+                return Poll::Ready(Ok(output));
             }
         }
 
         if all_done {
             let mut elems = mem::replace(&mut self.elems, Box::pin([]));
             let result: Vec<E> = iter_pin_mut(elems.as_mut())
-                .map(|e| e.take().unwrap().unwrap_err())
+                .map(|e| match e.take_err() {
+                    Some(err) => err,
+                    // Since all futures are done without any one of them returning `Ok`, they're
+                    // all `Err`s and so `take_err` cannot fail
+                    None => unreachable!(),
+                })
                 .collect();
             Poll::Ready(Err(AggregateError::new(result)))
         } else {

--- a/src/future/race_ok/vec/mod.rs
+++ b/src/future/race_ok/vec/mod.rs
@@ -41,8 +41,6 @@ where
 
 impl<Fut, T, E> Future for RaceOk<Fut, T, E>
 where
-    T: std::fmt::Debug,
-    E: fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
 {
     type Output = Result<T, AggregateError<E>>;
@@ -77,8 +75,6 @@ where
 
 impl<Fut, T, E> RaceOkTrait for Vec<Fut>
 where
-    T: fmt::Debug,
-    E: fmt::Debug,
     Fut: IntoFuture<Output = Result<T, E>>,
 {
     type Output = T;

--- a/src/future/try_join/array.rs
+++ b/src/future/try_join/array.rs
@@ -19,7 +19,6 @@ use pin_project::pin_project;
 #[pin_project]
 pub struct TryJoin<Fut, T, E, const N: usize>
 where
-    T: fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
 {
     elems: [MaybeDone<Fut>; N],
@@ -29,7 +28,6 @@ impl<Fut, T, E, const N: usize> fmt::Debug for TryJoin<Fut, T, E, N>
 where
     Fut: Future<Output = Result<T, E>> + fmt::Debug,
     Fut::Output: fmt::Debug,
-    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.elems.iter()).finish()
@@ -38,9 +36,7 @@ where
 
 impl<Fut, T, E, const N: usize> Future for TryJoin<Fut, T, E, N>
 where
-    T: fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
-    E: fmt::Debug,
 {
     type Output = Result<[T; N], E>;
 
@@ -89,9 +85,7 @@ where
 
 impl<Fut, T, E, const N: usize> TryJoinTrait for [Fut; N]
 where
-    T: std::fmt::Debug,
     Fut: IntoFuture<Output = Result<T, E>>,
-    E: fmt::Debug,
 {
     type Output = [T; N];
     type Error = E;

--- a/src/future/try_join/vec.rs
+++ b/src/future/try_join/vec.rs
@@ -37,7 +37,6 @@ where
 
 impl<Fut, T, E> Future for TryJoin<Fut, T, E>
 where
-    T: std::fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
 {
     type Output = Result<Vec<T>, E>;
@@ -72,7 +71,6 @@ where
 
 impl<Fut, T, E> TryJoinTrait for Vec<Fut>
 where
-    T: std::fmt::Debug,
     Fut: IntoFuture<Output = Result<T, E>>,
 {
     type Output = Vec<T>;

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -99,10 +99,9 @@ macro_rules! impl_merge_tuple {
         }
 
         impl<T, $($F),*> fmt::Debug for $StructName<T, $($F),*>
-        where $(
-            $F: Stream<Item = T> + fmt::Debug,
-            T: fmt::Debug,
-        )* {
+        where
+            $( $F: Stream<Item = T> + fmt::Debug, )*
+        {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple("Merge")
                     $( .field(&self.streams.$F) )* // Hides implementation detail of Streams struct


### PR DESCRIPTION
- feat: Introduce `MaybeDone::take(_ok|_err)` instead of `output() + take()` to avoid unwrapping and relying on `core::fmt::Debug`.
- chore: remove unecessary `fmt::Debug` requirements
