### PR TITLE
Update `Join` documentation

### DIFF
--- a/src/future/join/mod.rs
+++ b/src/future/join/mod.rs
@@ -7,19 +7,60 @@ pub(crate) mod vec;
 /// Wait for all futures to complete.
 ///
 /// Awaits multiple futures simultaneously, returning the output of the futures
-/// once all complete.
+/// in the same container type they we're created once all complete.
 pub trait Join {
     /// The resulting output type.
     type Output;
 
-    /// Which kind of future are we turning this into?
+    /// The [`Future`] implementation returned by this method.
     type Future: Future<Output = Self::Output>;
 
     /// Waits for multiple futures to complete.
     ///
-    /// Awaits multiple futures simultaneously, returning the output of the
-    /// futures once all complete.
+    /// Awaits multiple futures simultaneously, returning the output of the futures
+    /// in the same container type they we're created once all complete.
     ///
+    /// # Examples
+    /// Awaiting multiple futures of the same type can be done using either a vector
+    /// or an array.
+    /// ```rust
+    /// #  futures::executor::block_on(async {
+    /// use futures_concurrency::prelude::*;
+    ///
+    /// // these can be whatever kind of `Future` you have,
+    /// // as long as it all have the exactly same type
+    /// let fut1 = core::future::ready(1);
+    /// let fut2 = core::future::ready(2);
+    /// let fut3 = core::future::ready(3);
+    ///
+    /// let outputs = [fut1, fut2, fut3].join().await;
+    /// assert_eq!(outputs, [1, 2, 3]);
+    /// # })
+    /// ```
+    ///
+    /// But in real world, you might want to wait multiple futures of
+    /// different types - let's say you're awaiting on custom `async {}` blocks,
+    /// or that your futures have different `Output` types - for that, you can
+    /// `join` on tuples.
+    /// ```rust
+    /// #  futures::executor::block_on(async {
+    /// use futures_concurrency::prelude::*;
+    ///
+    /// async fn some_async_fn() -> usize { 3 }
+    ///
+    /// // these can be whatever kind of `Future` you have,
+    /// // even those that have totally different concrete types.
+    /// let fut1 = core::future::ready(1);
+    /// let fut2 = async { 2 };
+    /// let fut3 = some_async_fn();
+    /// //                       ^ NOTE: no `.await` here!
+    ///
+    /// let outputs = (fut1, fut2, fut3).join().await;
+    /// assert_eq!(outputs, (1, 2, 3));
+    /// # })
+    /// ```
+    ///
+    /// <br><br>
     /// This function returns a new future which polls all futures concurrently.
     fn join(self) -> Self::Future;
 }

--- a/src/future/join/mod.rs
+++ b/src/future/join/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod vec;
 /// Wait for all futures to complete.
 ///
 /// Awaits multiple futures simultaneously, returning the output of the futures
-/// in the same container type they we're created once all complete.
+/// in the same container type they were created once all complete.
 pub trait Join {
     /// The resulting output type.
     type Output;
@@ -21,14 +21,14 @@ pub trait Join {
     /// in the same container type they we're created once all complete.
     ///
     /// # Examples
+    ///
     /// Awaiting multiple futures of the same type can be done using either a vector
     /// or an array.
     /// ```rust
     /// #  futures::executor::block_on(async {
     /// use futures_concurrency::prelude::*;
     ///
-    /// // these can be whatever kind of `Future` you have,
-    /// // as long as it all have the exactly same type
+    /// // all futures passed here are of the same type
     /// let fut1 = core::future::ready(1);
     /// let fut2 = core::future::ready(2);
     /// let fut3 = core::future::ready(3);
@@ -38,18 +38,16 @@ pub trait Join {
     /// # })
     /// ```
     ///
-    /// But in real world, you might want to wait multiple futures of
-    /// different types - let's say you're awaiting on custom `async {}` blocks,
-    /// or that your futures have different `Output` types - for that, you can
-    /// `join` on tuples.
+    /// In practice however, it's common to want to await multiple futures of
+    /// different types. For example if you have two different `async {}` blocks,
+    /// you want to `.await`. To do that, you can call `.join` on tuples of futures.
     /// ```rust
     /// #  futures::executor::block_on(async {
     /// use futures_concurrency::prelude::*;
     ///
     /// async fn some_async_fn() -> usize { 3 }
     ///
-    /// // these can be whatever kind of `Future` you have,
-    /// // even those that have totally different concrete types.
+    /// // the futures passed here are of different types
     /// let fut1 = core::future::ready(1);
     /// let fut2 = async { 2 };
     /// let fut3 = some_async_fn();

--- a/src/future/join/vec.rs
+++ b/src/future/join/vec.rs
@@ -10,7 +10,7 @@ use std::vec::Vec;
 
 use pin_project::{pin_project, pinned_drop};
 
-/// A future which waits for two similarly-typed futures to complete.
+/// A future which waits for multiple futures to complete.
 ///
 /// This `struct` is created by the [`join`] method on the [`Join`] trait. See
 /// its documentation for more.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@
 //! remove the need to think of "merge" as a verb, and would enable treating
 //! sets of futures concurrently.
 
-
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub)]
 #![allow(non_snake_case)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,29 @@
 //!
 //! This library provides the following operations on arrays, vecs, and tuples:
 //!
-//! - [`future::Join`] Wait for all futures to complete.
-//! - [`future::TryJoin`] Wait for all futures to complete successfully, or abort early on error.
-//! - [`future::Race`] Wait for the first future to complete.
-//! - [`future::RaceOk`] Wait for the first successful future to complete.
-//! - [`stream::Chain`] Takes multiple streams and creates a new stream over all in sequence.
-//! - [`stream::Merge`] Combines multiple streams into a single stream of all their outputs.
-//! - [`stream::Zip`] ‘Zips up’ multiple streams into a single stream of pairs.
+//! - [`future::Join`]: Wait for all futures to complete.
+//! - [`future::TryJoin`]: Wait for all futures to complete successfully, or abort early on error.
+//! - [`future::Race`]: Wait for the first future to complete.
+//! - [`future::RaceOk`]: Wait for the first successful future to complete.
+//! - [`stream::Chain`]: Takes multiple streams and creates a new stream over all in sequence.
+//! - [`stream::Merge`]: Combines multiple streams into a single stream of all their outputs.
+//! - [`stream::Zip`]: ‘Zips up’ multiple streams into a single stream of pairs.
+//!
+//! # Examples
+//!
+//! Concurrently await multiple heterogenous futures:
+//! ```rust
+//! use futures_concurrency::prelude::*;
+//! use futures_lite::future::block_on;
+//! use std::future;
+//!
+//! block_on(async {
+//!     let a = future::ready(1u8);
+//!     let b = future::ready("hello");
+//!     let c = future::ready(3u16);
+//!     assert_eq!((a, b, c).join().await, (1, "hello", 3));
+//! })
+//! ```
 //!
 //! # Limitations
 //!
@@ -41,22 +57,7 @@
 //! `for..await in` loops to be iterated over using `merge` semantics. This would
 //! remove the need to think of "merge" as a verb, and would enable treating
 //! sets of futures concurrently.
-//!
-//! # Examples
-//!
-//! Concurrently await multiple heterogenous futures:
-//! ```rust
-//! use futures_concurrency::prelude::*;
-//! use futures_lite::future::block_on;
-//! use std::future;
-//!
-//! block_on(async {
-//!     let a = future::ready(1u8);
-//!     let b = future::ready("hello");
-//!     let c = future::ready(3u16);
-//!     assert_eq!((a, b, c).join().await, (1, "hello", 3));
-//! })
-//! ```
+
 
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! - [`future::Join`] Wait for all futures to complete.
 //! - [`future::TryJoin`] Wait for all futures to complete successfully, or abort early on error.
-//! - [`future::Race`] Wait for all futures to complete successfully, or abort early on error.
+//! - [`future::Race`] Wait for the first future to complete.
 //! - [`future::RaceOk`] Wait for the first successful future to complete.
 //! - [`stream::Chain`] Takes multiple streams and creates a new stream over all in sequence.
 //! - [`stream::Merge`] Combines multiple streams into a single stream of all their outputs.
@@ -93,7 +93,8 @@ pub mod array {
     pub use crate::stream::zip::array::Zip;
 }
 
-/// A contiguous growable array type with heap-allocated contents, written `Vec<T>`.
+/// Helper functions and types for contiguous growable array type with heap-allocated contents,
+/// written `Vec<T>`.
 pub mod vec {
     pub use crate::future::join::vec::Join;
     pub use crate::future::race::vec::Race;


### PR DESCRIPTION
I've been thinking about working a bit on the public documentation of this crate.

My plan is to first revisit the traits in the next feel days, and then improve the first page/crate documentation and readme. Instead of opening a big-ass PR, I want to iterate over the traits one PR at a time, so we can have a nicer feedback loop.

This first PR should improve a bit the docs of `Join` (it also provides a few minor fixes on `lib.rs`).

Let me know what you think!