### PR TITLE
Make tuple types public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,36 @@ pub mod prelude {
 pub mod future;
 pub mod stream;
 
+/// Helper functions and types for tuples.
+pub mod tuple {
+    pub use crate::future::join::tuple::{
+        Join0, Join1, Join10, Join11, Join12, Join2, Join3, Join4, Join5, Join6, Join7, Join8,
+        Join9,
+    };
+    pub use crate::future::race::tuple::{
+        Race1, Race10, Race11, Race12, Race2, Race3, Race4, Race5, Race6, Race7, Race8, Race9,
+    };
+    pub use crate::future::race_ok::tuple::{
+        RaceOk1, RaceOk10, RaceOk11, RaceOk12, RaceOk2, RaceOk3, RaceOk4, RaceOk5, RaceOk6,
+        RaceOk7, RaceOk8, RaceOk9,
+    };
+    pub use crate::future::try_join::tuple::{
+        TryJoin1, TryJoin10, TryJoin11, TryJoin12, TryJoin2, TryJoin3, TryJoin4, TryJoin5,
+        TryJoin6, TryJoin7, TryJoin8, TryJoin9,
+    };
+    pub use crate::stream::chain::tuple::{
+        Chain1, Chain10, Chain11, Chain12, Chain2, Chain3, Chain4, Chain5, Chain6, Chain7, Chain8,
+        Chain9,
+    };
+    pub use crate::stream::merge::tuple::{
+        Merge0, Merge1, Merge10, Merge11, Merge12, Merge2, Merge3, Merge4, Merge5, Merge6, Merge7,
+        Merge8, Merge9,
+    };
+    pub use crate::stream::zip::tuple::{
+        Zip1, Zip10, Zip11, Zip12, Zip2, Zip3, Zip4, Zip5, Zip6, Zip7, Zip8, Zip9,
+    };
+}
+
 /// Helper functions and types for fixed-length arrays.
 pub mod array {
     pub use crate::future::join::array::Join;

--- a/src/stream/chain/tuple.rs
+++ b/src/stream/chain/tuple.rs
@@ -21,6 +21,13 @@ macro_rules! impl_chain_for_tuple {
             pub(super) const LEN: usize = [$(Indexes::$F,)+].len();
         }
 
+        /// A stream that chains multiple streams one after another.
+        ///
+        /// This `struct` is created by the [`chain`] method on the [`Chain`] trait. See its
+        /// documentation for more.
+        ///
+        /// [`chain`]: crate::stream::Chain::chain
+        /// [`Chain`]: crate::stream::Chain
         #[pin_project::pin_project]
         pub struct $StructName<$($F,)+> {
             index: usize,

--- a/src/stream/merge/tuple.rs
+++ b/src/stream/merge/tuple.rs
@@ -41,8 +41,8 @@ macro_rules! impl_merge_tuple {
         /// This `struct` is created by the [`merge`] method on the [`Merge`] trait. See its
         /// documentation for more.
         ///
-        /// [`merge`]: trait.Merge.html#method.merge
-        /// [`Merge`]: trait.Merge.html
+        /// [`merge`]: crate::stream::Merge::merge
+        /// [`Merge`]: crate::stream::Merge
         pub struct $StructName {}
 
         impl fmt::Debug for $StructName {

--- a/src/stream/zip/tuple.rs
+++ b/src/stream/zip/tuple.rs
@@ -41,6 +41,13 @@ macro_rules! impl_zip_for_tuple {
             pub(super) const LEN: usize = [$(Indexes::$F,)+].len();
         }
 
+        /// A stream that ‘zips up’ multiple streams into a single stream of pairs.
+        ///
+        /// This `struct` is created by the [`zip`] method on the [`Zip`] trait. See its
+        /// documentation for more.
+        ///
+        /// [`zip`]: crate::stream::Zip::zip
+        /// [`Zip`]: crate::stream::Zip
         #[pin_project::pin_project(PinnedDrop)]
         pub struct $StructName<$($F,)+>
         where


### PR DESCRIPTION
This updates all tuple implementation types of `future::{Join, TryJoin, Race, RaceOk}` and `stream::{Chain, Merge, Zip}` to be publicly exported out of `crate::tuple`, just like all `Vec` and `array` implementations in `crate::vec` and `crate::array`.

Besides for symmetry, my motivation with this change was to allow easier naming of types that use these combinators (without needing to resort to `impl Trait` syntax) and to allow implementing a trait on the concrete implementations for added functionality.

For example, I wanted to write some type like:
```
pub type MathOperator<Fut1, Fut2, F> = Map<Join2<Fut1, Fut2>, F>;
```