### PR TITLE
Drop futures as soon as they're done for `array::join`

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -1,5 +1,5 @@
 use super::Join as JoinTrait;
-use crate::utils::{self, PollArray, WakerArray};
+use crate::utils::{self, array_to_maybe_uninit, PollArray, WakerArray};
 
 use core::array;
 use core::fmt;
@@ -9,14 +9,6 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use pin_project::{pin_project, pinned_drop};
-
-/// Cast an array of `T` to an array of `MaybeUninit<T>`
-fn array_to_maybe_uninit<T, const N: usize>(arr: [T; N]) -> [MaybeUninit<T>; N] {
-    // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
-    let arr = MaybeUninit::new(arr);
-    // SAFETY: T and MaybeUninit<T> have the same layout
-    unsafe { mem::transmute_copy(&mem::ManuallyDrop::new(arr)) }
-}
 
 /// A future which waits for two similarly-typed futures to complete.
 ///

--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -103,6 +103,7 @@ where
                 let mut cx = Context::from_waker(this.wakers.get(i).unwrap());
 
                 // Poll the future
+                // SAFETY: we checked the future state was "pending"
                 if let Poll::Ready(value) = unsafe {
                     fut.as_mut()
                         .map_unchecked_mut(|t| t.assume_init_mut())

--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -104,7 +104,7 @@ where
                 let mut cx = Context::from_waker(this.wakers.get(i).unwrap());
 
                 // Poll the future
-                // SAFETY: we checked the future state was "pending"
+                // SAFETY: the future's state was "pending", so it's safe to poll
                 if let Poll::Ready(value) = unsafe {
                     fut.as_mut()
                         .map_unchecked_mut(|t| t.deref_mut())
@@ -113,11 +113,8 @@ where
                     this.items[i] = MaybeUninit::new(value);
                     this.state[i].set_ready();
                     *this.pending -= 1;
-                }
-
-                // If the state was changed from "pending" to "ready", drop the future.
-                if this.state[i].is_ready() {
-                    // SAFETY: we're done with the future, drop in-place
+                    // SAFETY: the future state has been changed to "ready" which
+                    // means we'll no longer poll the future, so it's safe to drop
                     unsafe { ManuallyDrop::drop(fut.get_unchecked_mut()) };
                 }
 

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -1,4 +1,4 @@
-use std::mem::{self, ManuallyDrop, MaybeUninit};
+use std::mem::{self, MaybeUninit};
 
 /// Extracts the values from an array of `MaybeUninit` containers.
 ///
@@ -19,12 +19,4 @@ pub(crate) unsafe fn array_assume_init<T, const N: usize>(array: [MaybeUninit<T>
     // FIXME: required to avoid `~const Destruct` bound
     mem::forget(array);
     ret
-}
-
-/// Cast an array of `T` to an array of `MaybeUninit<T>`
-pub(crate) fn array_to_manually_drop<T, const N: usize>(arr: [T; N]) -> [ManuallyDrop<T>; N] {
-    // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
-    let arr = MaybeUninit::new(arr);
-    // SAFETY: T and MaybeUninit<T> have the same layout
-    unsafe { mem::transmute_copy(&mem::ManuallyDrop::new(arr)) }
 }

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -20,3 +20,11 @@ pub(crate) unsafe fn array_assume_init<T, const N: usize>(array: [MaybeUninit<T>
     mem::forget(array);
     ret
 }
+
+/// Cast an array of `T` to an array of `MaybeUninit<T>`
+pub(crate) fn array_to_maybe_uninit<T, const N: usize>(arr: [T; N]) -> [MaybeUninit<T>; N] {
+    // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
+    let arr = MaybeUninit::new(arr);
+    // SAFETY: T and MaybeUninit<T> have the same layout
+    unsafe { mem::transmute_copy(&mem::ManuallyDrop::new(arr)) }
+}

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -1,4 +1,4 @@
-use std::mem::{self, MaybeUninit};
+use std::mem::{self, ManuallyDrop, MaybeUninit};
 
 /// Extracts the values from an array of `MaybeUninit` containers.
 ///
@@ -22,7 +22,7 @@ pub(crate) unsafe fn array_assume_init<T, const N: usize>(array: [MaybeUninit<T>
 }
 
 /// Cast an array of `T` to an array of `MaybeUninit<T>`
-pub(crate) fn array_to_maybe_uninit<T, const N: usize>(arr: [T; N]) -> [MaybeUninit<T>; N] {
+pub(crate) fn array_to_manually_drop<T, const N: usize>(arr: [T; N]) -> [ManuallyDrop<T>; N] {
     // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
     let arr = MaybeUninit::new(arr);
     // SAFETY: T and MaybeUninit<T> have the same layout

--- a/src/utils/futures/array.rs
+++ b/src/utils/futures/array.rs
@@ -1,0 +1,44 @@
+use std::{
+    mem::{self, ManuallyDrop, MaybeUninit},
+    pin::Pin,
+};
+
+/// An array of futures which can be dropped in-place, intended to be
+/// constructed once and then accessed through pin projections.
+pub(crate) struct FutureArray<T, const N: usize> {
+    futures: [ManuallyDrop<T>; N],
+}
+
+impl<T, const N: usize> FutureArray<T, N> {
+    /// Create a new instance of `FutureArray`
+    pub(crate) fn new(futures: [T; N]) -> Self {
+        // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
+        let futures = MaybeUninit::new(futures);
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        let futures = unsafe { mem::transmute_copy(&mem::ManuallyDrop::new(futures)) };
+        Self { futures }
+    }
+
+    /// Create an iterator of pinned references.
+    pub(crate) fn iter(self: Pin<&mut Self>) -> impl Iterator<Item = Pin<&mut ManuallyDrop<T>>> {
+        // SAFETY: `std` _could_ make this unsound if it were to decide Pin's
+        // invariants aren't required to transmit through slices. Otherwise this has
+        // the same safety as a normal field pin projection.
+        unsafe { self.get_unchecked_mut() }
+            .futures
+            .iter_mut()
+            .map(|t| unsafe { Pin::new_unchecked(t) })
+    }
+
+    /// Drop a future at the given index.
+    ///
+    /// # Safety
+    ///
+    /// The future is held in a `ManuallyDrop`, so no double-dropping, etc
+    pub(crate) unsafe fn drop(mut self: Pin<&mut Self>, idx: usize) {
+        unsafe {
+            let futures = self.as_mut().get_unchecked_mut().futures.as_mut();
+            ManuallyDrop::drop(&mut futures[idx]);
+        };
+    }
+}

--- a/src/utils/futures/mod.rs
+++ b/src/utils/futures/mod.rs
@@ -1,0 +1,3 @@
+mod array;
+
+pub(crate) use array::FutureArray;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,7 @@ mod poll_state;
 mod tuple;
 mod wakers;
 
-pub(crate) use array::{array_assume_init, array_to_maybe_uninit};
+pub(crate) use array::{array_assume_init, array_to_manually_drop};
 pub(crate) use indexer::Indexer;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::MaybeDone;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,13 +1,15 @@
 //! Utilities to implement the different futures of this crate.
 
 mod array;
+mod futures;
 mod indexer;
 mod pin;
 mod poll_state;
 mod tuple;
 mod wakers;
 
-pub(crate) use array::{array_assume_init, array_to_manually_drop};
+pub(crate) use self::futures::FutureArray;
+pub(crate) use array::array_assume_init;
 pub(crate) use indexer::Indexer;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::MaybeDone;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,7 @@ mod poll_state;
 mod tuple;
 mod wakers;
 
-pub(crate) use array::array_assume_init;
+pub(crate) use array::{array_assume_init, array_to_maybe_uninit};
 pub(crate) use indexer::Indexer;
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::MaybeDone;


### PR DESCRIPTION
Makes progress towards #137. If we accept this fix we'll want to copy it for all our APIs.