### PR TITLE
Output structure

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@
 mod array;
 mod futures;
 mod indexer;
+mod output;
 mod pin;
 mod poll_state;
 mod tuple;
@@ -11,6 +12,7 @@ mod wakers;
 pub(crate) use self::futures::FutureArray;
 pub(crate) use array::array_assume_init;
 pub(crate) use indexer::Indexer;
+pub(crate) use output::{OutputArray, OutputVec};
 pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
 pub(crate) use poll_state::MaybeDone;
 pub(crate) use poll_state::{PollArray, PollState, PollVec};

--- a/src/utils/output/array.rs
+++ b/src/utils/output/array.rs
@@ -1,0 +1,49 @@
+use std::{
+    array,
+    mem::{self, MaybeUninit},
+};
+
+use crate::utils;
+
+/// A contiguous array of uninitialized data.
+pub(crate) struct OutputArray<T, const N: usize> {
+    data: [MaybeUninit<T>; N],
+}
+
+impl<T, const N: usize> OutputArray<T, N> {
+    /// Initialize a new array as uninitialized
+    pub(crate) fn uninit() -> Self {
+        Self {
+            data: array::from_fn(|_| MaybeUninit::uninit()),
+        }
+    }
+
+    /// Write a value into memory at the index
+    pub(crate) fn write(&mut self, idx: usize, value: T) {
+        self.data[idx] = MaybeUninit::new(value);
+    }
+
+    /// Drop a value at the index
+    ///
+    /// # Safety
+    ///
+    /// The value at the index must be initialized
+    pub(crate) unsafe fn drop(&mut self, idx: usize) {
+        // SAFETY: The caller is responsible for ensuring this value is
+        // initialized
+        unsafe { self.data[idx].assume_init_drop() };
+    }
+
+    /// Assume all items are initialized and take the items,
+    /// leaving behind uninitialized data.
+    ///
+    /// # Safety
+    ///
+    /// Make sure that all items are initialized prior to calling this method.
+    pub(crate) unsafe fn take(&mut self) -> [T; N] {
+        let mut data = array::from_fn(|_| MaybeUninit::uninit());
+        mem::swap(&mut self.data, &mut data);
+        // SAFETY: the caller is on the hook to ensure all items are initialized
+        unsafe { utils::array_assume_init(data) }
+    }
+}

--- a/src/utils/output/mod.rs
+++ b/src/utils/output/mod.rs
@@ -1,0 +1,5 @@
+mod array;
+mod vec;
+
+pub(crate) use array::OutputArray;
+pub(crate) use vec::OutputVec;

--- a/src/utils/output/vec.rs
+++ b/src/utils/output/vec.rs
@@ -1,1 +1,49 @@
-pub(crate) struct OutputVec;
+use std::mem::{self, MaybeUninit};
+
+/// A contiguous vector of uninitialized data.
+pub(crate) struct OutputVec<T> {
+    data: Vec<T>,
+    capacity: usize,
+}
+
+impl<T> OutputVec<T> {
+    /// Initialize a new vector as uninitialized
+    pub(crate) fn uninit(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Write a value into memory at the index
+    pub(crate) fn write(&mut self, idx: usize, value: T) {
+        let data = self.data.spare_capacity_mut();
+        data[idx] = MaybeUninit::new(value);
+    }
+
+    /// Drop a value at the index
+    ///
+    /// # Safety
+    ///
+    /// The value at the index must be initialized
+    pub(crate) unsafe fn drop(&mut self, idx: usize) {
+        // SAFETY: The caller is responsible for ensuring this value is
+        // initialized
+        let data = self.data.spare_capacity_mut();
+        unsafe { data[idx].assume_init_drop() };
+    }
+
+    /// Assume all items are initialized and take the items,
+    /// leaving behind an empty vector
+    ///
+    /// # Safety
+    ///
+    /// Make sure that all items are initialized prior to calling this method.
+    pub(crate) unsafe fn take(&mut self) -> Vec<T> {
+        let mut data = vec![];
+        mem::swap(&mut self.data, &mut data);
+        // SAFETY: the caller is on the hook to ensure all items are initialized
+        unsafe { data.set_len(self.capacity) };
+        data
+    }
+}

--- a/src/utils/output/vec.rs
+++ b/src/utils/output/vec.rs
@@ -1,0 +1,1 @@
+pub(crate) struct OutputVec;


### PR DESCRIPTION
This moves a lot of the inline unsafe `MaybeUninit` output data things into their own structures. This is most helpful when you need to potentially catch _all_ data. But there are a number of APIs like that, so this seems like it should be roughly right.