### PR TITLE
move indexing logic to the state structures

### DIFF
--- a/src/future/join/array.rs
+++ b/src/future/join/array.rs
@@ -159,31 +159,15 @@ where
     fn drop(self: Pin<&mut Self>) {
         let mut this = self.project();
 
-        // Get the indexes of the initialized output values.
-        let indexes = this
-            .state
-            .iter_mut()
-            .enumerate()
-            .filter(|(_, state)| state.is_ready())
-            .map(|(i, _)| i);
-
-        // Drop each value at the index.
-        for i in indexes {
+        // Drop all initialized values.
+        for i in this.state.ready_indexes() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
             unsafe { this.items.drop(i) };
         }
 
-        // Get the indexes of the pending futures.
-        let indexes = this
-            .state
-            .iter_mut()
-            .enumerate()
-            .filter(|(_, state)| state.is_pending())
-            .map(|(i, _)| i);
-
-        // Drop each future at the index.
-        for i in indexes {
+        // Drop all pending futures.
+        for i in this.state.pending_indexes() {
             // SAFETY: we've just filtered down to *only* the pending futures,
             // which have not yet been dropped.
             unsafe { this.futures.as_mut().drop(i) };

--- a/src/future/join/vec.rs
+++ b/src/future/join/vec.rs
@@ -142,16 +142,8 @@ where
     fn drop(self: Pin<&mut Self>) {
         let this = self.project();
 
-        // Get the indexes of the initialized values.
-        let indexes = this
-            .state
-            .iter_mut()
-            .enumerate()
-            .filter(|(_, state)| state.is_ready())
-            .map(|(i, _)| i);
-
-        // Drop each value at the index.
-        for i in indexes {
+        // Drop all initialized values.
+        for i in this.state.ready_indexes() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
             unsafe { this.items.drop(i) };

--- a/src/utils/poll_state/array.rs
+++ b/src/utils/poll_state/array.rs
@@ -26,7 +26,7 @@ impl<const N: usize> PollArray<N> {
     }
 
     /// Get an iterator of indexes of all items which are "ready".
-    pub(crate) fn ready_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+    pub(crate) fn ready_indexes(&self) -> impl Iterator<Item = usize> + '_ {
         self.iter()
             .cloned()
             .enumerate()
@@ -35,7 +35,7 @@ impl<const N: usize> PollArray<N> {
     }
 
     /// Get an iterator of indexes of all items which are "pending".
-    pub(crate) fn pending_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+    pub(crate) fn pending_indexes(&self) -> impl Iterator<Item = usize> + '_ {
         self.iter()
             .cloned()
             .enumerate()

--- a/src/utils/poll_state/array.rs
+++ b/src/utils/poll_state/array.rs
@@ -13,6 +13,7 @@ impl<const N: usize> PollArray<N> {
         }
     }
 
+    /// Mark all items as "completed"
     #[inline]
     pub(crate) fn set_all_completed(&mut self) {
         self.iter_mut().for_each(|state| {
@@ -22,6 +23,24 @@ impl<const N: usize> PollArray<N> {
             );
             state.set_consumed();
         })
+    }
+
+    /// Get an iterator of indexes of all items which are "ready".
+    pub(crate) fn ready_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+        self.iter()
+            .cloned()
+            .enumerate()
+            .filter(|(_, state)| state.is_ready())
+            .map(|(i, _)| i)
+    }
+
+    /// Get an iterator of indexes of all items which are "pending".
+    pub(crate) fn pending_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+        self.iter()
+            .cloned()
+            .enumerate()
+            .filter(|(_, state)| state.is_pending())
+            .map(|(i, _)| i)
     }
 }
 

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -59,6 +59,7 @@ impl PollVec {
     }
 
     /// Get an iterator of indexes of all items which are "pending".
+    #[allow(unused)]
     pub(crate) fn pending_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
         self.iter()
             .cloned()

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -50,7 +50,7 @@ impl PollVec {
     }
 
     /// Get an iterator of indexes of all items which are "ready".
-    pub(crate) fn ready_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+    pub(crate) fn ready_indexes(&self) -> impl Iterator<Item = usize> + '_ {
         self.iter()
             .cloned()
             .enumerate()
@@ -60,7 +60,7 @@ impl PollVec {
 
     /// Get an iterator of indexes of all items which are "pending".
     #[allow(unused)]
-    pub(crate) fn pending_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+    pub(crate) fn pending_indexes(&self) -> impl Iterator<Item = usize> + '_ {
         self.iter()
             .cloned()
             .enumerate()

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -48,6 +48,24 @@ impl PollVec {
             Self::Boxed(states.into_boxed_slice())
         }
     }
+
+    /// Get an iterator of indexes of all items which are "ready".
+    pub(crate) fn ready_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+        self.iter()
+            .cloned()
+            .enumerate()
+            .filter(|(_, state)| state.is_ready())
+            .map(|(i, _)| i)
+    }
+
+    /// Get an iterator of indexes of all items which are "pending".
+    pub(crate) fn pending_indexes<'a>(&'a self) -> impl Iterator<Item = usize> + 'a {
+        self.iter()
+            .cloned()
+            .enumerate()
+            .filter(|(_, state)| state.is_pending())
+            .map(|(i, _)| i)
+    }
 }
 
 impl Deref for PollVec {


### PR DESCRIPTION
This should make the drop impls for custom structures a bit more portable between implementations. Thanks!