### PR TITLE
Drop futures as soon as they're done for `vec::join`

### DIFF
--- a/src/utils/futures/mod.rs
+++ b/src/utils/futures/mod.rs
@@ -1,3 +1,5 @@
 mod array;
+mod vec;
 
 pub(crate) use array::FutureArray;
+pub(crate) use vec::FutureVec;

--- a/src/utils/futures/vec.rs
+++ b/src/utils/futures/vec.rs
@@ -1,0 +1,44 @@
+use std::{
+    mem::{self, ManuallyDrop, MaybeUninit},
+    pin::Pin,
+};
+
+/// An array of futures which can be dropped in-place, intended to be
+/// constructed once and then accessed through pin projections.
+pub(crate) struct FutureVec<T> {
+    futures: Vec<ManuallyDrop<T>>,
+}
+
+impl<T> FutureVec<T> {
+    /// Create a new instance of `FutureVec`
+    pub(crate) fn new(futures: Vec<T>) -> Self {
+        // Implementation copied from: https://doc.rust-lang.org/src/core/mem/maybe_uninit.rs.html#1292
+        let futures = MaybeUninit::new(futures);
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        let futures = unsafe { mem::transmute_copy(&mem::ManuallyDrop::new(futures)) };
+        Self { futures }
+    }
+
+    /// Create an iterator of pinned references.
+    pub(crate) fn iter(self: Pin<&mut Self>) -> impl Iterator<Item = Pin<&mut ManuallyDrop<T>>> {
+        // SAFETY: `std` _could_ make this unsound if it were to decide Pin's
+        // invariants aren't required to transmit through slices. Otherwise this has
+        // the same safety as a normal field pin projection.
+        unsafe { self.get_unchecked_mut() }
+            .futures
+            .iter_mut()
+            .map(|t| unsafe { Pin::new_unchecked(t) })
+    }
+
+    /// Drop a future at the given index.
+    ///
+    /// # Safety
+    ///
+    /// The future is held in a `ManuallyDrop`, so no double-dropping, etc
+    pub(crate) unsafe fn drop(mut self: Pin<&mut Self>, idx: usize) {
+        unsafe {
+            let futures = self.as_mut().get_unchecked_mut().futures.as_mut_slice();
+            ManuallyDrop::drop(&mut futures[idx]);
+        };
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,7 @@ mod poll_state;
 mod tuple;
 mod wakers;
 
-pub(crate) use self::futures::FutureArray;
+pub(crate) use self::futures::{FutureArray, FutureVec};
 pub(crate) use array::array_assume_init;
 pub(crate) use indexer::Indexer;
 pub(crate) use output::{OutputArray, OutputVec};


### PR DESCRIPTION
Makes progress towards #137. Thanks!