### PR TITLE
remove macro warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! sets of futures concurrently.
 
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs)]
 #![allow(non_snake_case)]
 
 mod utils;


### PR DESCRIPTION
`pin_project` in macros was giving lots of warnings; this gets rid of those