### PR TITLE
Add a new `future::FutureGroup` type for dynamic async concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
 pin-project = "1.0.8"
 slab = "0.4.8"
+async-iterator = "2.1.0"
 
 [dev-dependencies]
 async-channel = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ pin-project = "1.0.8"
 slab = "0.4.8"
 
 [dev-dependencies]
+async-channel = "1.9.0"
 futures = "0.3.25"
 futures-lite = "1.12.0"
 criterion = { version = "0.3", features = ["async", "async_futures", "html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
 pin-project = "1.0.8"
 slab = "0.4.8"
-async-iterator = "2.1.0"
 
 [dev-dependencies]
 async-channel = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ harness = false
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures-core = "0.3"
 pin-project = "1.0.8"
+slab = "0.4.8"
 
 [dev-dependencies]
 futures = "0.3.25"

--- a/src/future/future_set.rs
+++ b/src/future/future_set.rs
@@ -11,7 +11,7 @@ use std::task::Poll;
 
 /// A handle to a dynamic set of futures.
 ///
-/// See [`FutureSet`] for more.
+/// This is returned by calling the [`handle`][`FutureSet::handle`] method on [`FutureSet`].
 #[derive(Clone)]
 #[pin_project]
 pub struct FutureSetHandle<T> {

--- a/src/future/future_set.rs
+++ b/src/future/future_set.rs
@@ -1,0 +1,128 @@
+use futures_core::Stream;
+use pin_project::pin_project;
+use slab::Slab;
+use std::fmt::{self, Debug};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock};
+use std::task::Poll;
+
+/// A handle to a dynamic set of futures.
+#[pin_project]
+pub struct FutureSetHandle<T> {
+    #[pin]
+    futures: Arc<RwLock<Slab<Pin<Box<dyn Future<Output = T> + 'static>>>>>,
+    active: Arc<AtomicBool>,
+}
+
+impl<T: Debug> Debug for FutureSetHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FutureSet").field("slab", &"[..]").finish()
+    }
+}
+
+impl<T> FutureSetHandle<T> {
+    /// Return the number of futures currently active in the set.
+    pub fn len(&self) -> usize {
+        self.futures.read().unwrap().len()
+    }
+
+    /// Returns true if there are no futures currently active in the set.
+    pub fn is_empty(&self) -> bool {
+        self.futures.read().unwrap().is_empty()
+    }
+
+    /// Insert a new future into the set.
+    pub fn insert<Fut>(&self, fut: Fut)
+    where
+        Fut: Future<Output = T> + 'static,
+    {
+        self.futures.write().unwrap().insert(Box::pin(fut));
+    }
+}
+
+/// A dynamic set of futures.
+#[must_use = "`FutureSet` does nothing if not iterated over"]
+#[pin_project]
+pub struct FutureSet<T> {
+    #[pin]
+    futures: Arc<RwLock<Slab<Pin<Box<dyn Future<Output = T> + 'static>>>>>,
+    active: Arc<AtomicBool>,
+}
+
+impl<T: Debug> Debug for FutureSet<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FutureSet").field("slab", &"[..]").finish()
+    }
+}
+
+impl<T> FutureSet<T> {
+    /// Create a new instance of `FutureSet`.
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Create a new instance of `FutureSet` with a given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(false)),
+            futures: Arc::new(RwLock::new(Slab::with_capacity(capacity))),
+        }
+    }
+
+    /// Return the number of futures currently active in the set.
+    pub fn len(&self) -> usize {
+        self.futures.read().unwrap().len()
+    }
+
+    /// Returns true if there are no futures currently active in the set.
+    pub fn is_empty(&self) -> bool {
+        self.futures.read().unwrap().is_empty()
+    }
+
+    /// Insert a new future into the set.
+    pub fn insert<Fut>(&self, fut: Fut)
+    where
+        Fut: Future<Output = T> + 'static,
+    {
+        self.futures.write().unwrap().insert(Box::pin(fut));
+    }
+
+    /// Obtain a handle to the set which can be used to insert more futures into the set.
+    pub fn handle(&self) -> FutureSetHandle<T> {
+        FutureSetHandle {
+            futures: self.futures.clone(),
+            active: self.active.clone(),
+        }
+    }
+}
+
+impl<T> Stream for FutureSet<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.project();
+        let mut futures = this.futures.write().unwrap();
+
+        // Short-circuit if we have no futures to iterate over
+        if futures.is_empty() {
+            return Poll::Ready(None);
+        }
+
+        for (index, future) in futures.iter_mut() {
+            match Pin::new(future).poll(cx) {
+                std::task::Poll::Ready(item) => {
+                    // A future resolved. Remove it from the set, and return its value.
+                    futures.remove(index);
+                    return Poll::Ready(Some(item));
+                }
+                std::task::Poll::Pending => continue,
+            };
+        }
+        Poll::Pending
+    }
+}

--- a/src/future/future_set.rs
+++ b/src/future/future_set.rs
@@ -20,7 +20,7 @@ use std::task::Poll;
 /// set.insert(async { 7 });
 ///
 /// let mut out = 0;
-/// while let Some(num) = set.next().await {
+/// while let Some((num, _)) = set.next().await {
 ///     out += num;
 /// }
 /// assert_eq!(out, 12);
@@ -29,7 +29,7 @@ use std::task::Poll;
 #[must_use = "`FutureSet` does nothing if not iterated over"]
 #[derive(Default)]
 pub struct FutureSet<T> {
-    futures: Slab<Pin<Box<dyn Future<Output = T> + 'static>>>,
+    futures: Slab<Pin<Box<dyn Future<Output = T>>>>,
 }
 
 impl<T: Debug> Debug for FutureSet<T> {

--- a/src/future/future_set.rs
+++ b/src/future/future_set.rs
@@ -1,19 +1,23 @@
 use futures_core::Stream;
 use pin_project::pin_project;
 use slab::Slab;
+use std::error;
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::task::Poll;
 
 /// A handle to a dynamic set of futures.
+///
+/// See [`FutureSet`] for more.
+#[derive(Clone)]
 #[pin_project]
 pub struct FutureSetHandle<T> {
     #[pin]
     futures: Arc<RwLock<Slab<Pin<Box<dyn Future<Output = T> + 'static>>>>>,
-    active: Arc<AtomicBool>,
+    is_active: Arc<AtomicBool>,
 }
 
 impl<T: Debug> Debug for FutureSetHandle<T> {
@@ -34,21 +38,45 @@ impl<T> FutureSetHandle<T> {
     }
 
     /// Insert a new future into the set.
-    pub fn insert<Fut>(&self, fut: Fut)
+    pub fn insert<Fut>(&self, fut: Fut) -> Result<(), InsertError>
     where
         Fut: Future<Output = T> + 'static,
     {
+        if !self.is_active.load(Ordering::SeqCst) {
+            return Err(InsertError { _sealed: () });
+        }
         self.futures.write().unwrap().insert(Box::pin(fut));
+        Ok(())
+    }
+}
+/// An error returned from [`FutureSetHandle::insert()`].
+///
+/// Received because the underlying `FutureSet` no longer exists.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct InsertError {
+    _sealed: (),
+}
+
+impl error::Error for InsertError {}
+
+impl Debug for InsertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InsertError(..)")
+    }
+}
+impl fmt::Display for InsertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "inserting on a `FutureSet` which no longer exists")
     }
 }
 
 /// A dynamic set of futures.
 #[must_use = "`FutureSet` does nothing if not iterated over"]
-#[pin_project]
+#[pin_project(PinnedDrop)]
 pub struct FutureSet<T> {
     #[pin]
     futures: Arc<RwLock<Slab<Pin<Box<dyn Future<Output = T> + 'static>>>>>,
-    active: Arc<AtomicBool>,
+    is_active: Arc<AtomicBool>,
 }
 
 impl<T: Debug> Debug for FutureSet<T> {
@@ -66,7 +94,7 @@ impl<T> FutureSet<T> {
     /// Create a new instance of `FutureSet` with a given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            active: Arc::new(AtomicBool::new(false)),
+            is_active: Arc::new(AtomicBool::new(false)),
             futures: Arc::new(RwLock::new(Slab::with_capacity(capacity))),
         }
     }
@@ -93,7 +121,7 @@ impl<T> FutureSet<T> {
     pub fn handle(&self) -> FutureSetHandle<T> {
         FutureSetHandle {
             futures: self.futures.clone(),
-            active: self.active.clone(),
+            is_active: self.is_active.clone(),
         }
     }
 }
@@ -124,5 +152,13 @@ impl<T> Stream for FutureSet<T> {
             };
         }
         Poll::Pending
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<T> PinnedDrop for FutureSet<T> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        this.is_active.store(true, Ordering::SeqCst);
     }
 }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -68,7 +68,7 @@
 //! - `future::RaceOk`: wait for the first _successful_ future in the set to
 //! complete, or return an `Err` if *no* futures complete successfully.
 //!
-pub use future_set::{FutureSet, FutureSetHandle};
+pub use future_set::FutureSet;
 pub use futures_ext::FutureExt;
 pub use join::Join;
 pub use race::Race;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -68,12 +68,14 @@
 //! - `future::RaceOk`: wait for the first _successful_ future in the set to
 //! complete, or return an `Err` if *no* futures complete successfully.
 //!
+pub use future_set::FutureSet;
 pub use futures_ext::FutureExt;
 pub use join::Join;
 pub use race::Race;
 pub use race_ok::RaceOk;
 pub use try_join::TryJoin;
 
+mod future_set;
 mod futures_ext;
 pub(crate) mod join;
 pub(crate) mod race;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -68,7 +68,7 @@
 //! - `future::RaceOk`: wait for the first _successful_ future in the set to
 //! complete, or return an `Err` if *no* futures complete successfully.
 //!
-pub use future_set::FutureSet;
+pub use future_set::{FutureSet, FutureSetHandle};
 pub use futures_ext::FutureExt;
 pub use join::Join;
 pub use race::Race;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! eventually may become the futures concurrency methods provided by the
 //! stdlib. See the [`future`] and [`stream`] submodules for more.
 //!
-//! # Operations
+//! # Static Concurrency
 //!
 //! This library provides the following operations on arrays, vecs, and tuples:
 //!
@@ -23,6 +23,13 @@
 //! - [`stream::Chain`]: Takes multiple streams and creates a new stream over all in sequence.
 //! - [`stream::Merge`]: Combines multiple streams into a single stream of all their outputs.
 //! - [`stream::Zip`]: ‘Zips up’ multiple streams into a single stream of pairs.
+//!
+//! # Dynamic Concurrency
+//!
+//! The following structures and operations are provided for operating on
+//! varying sets of futures and streams:
+//!
+//! - [`future::FutureSet`]: A dynamic set of futures which can be concurrently awaited.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs)]
 #![allow(non_snake_case)]
-#![feature(async_fn_in_trait)]
 
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs)]
 #![allow(non_snake_case)]
+#![feature(async_fn_in_trait)]
 
 mod utils;
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -47,6 +47,7 @@
 //!
 //! See the [future concurrency][crate::future#concurrency] documentation for
 //! more on futures concurrency.
+
 pub use chain::Chain;
 pub use into_stream::IntoStream;
 pub use merge::Merge;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,7 +13,9 @@ pub(crate) use self::futures::{FutureArray, FutureVec};
 pub(crate) use array::array_assume_init;
 pub(crate) use indexer::Indexer;
 pub(crate) use output::{OutputArray, OutputVec};
-pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
+pub(crate) use pin::{
+    get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_slab, iter_pin_mut_vec,
+};
 pub(crate) use poll_state::MaybeDone;
 pub(crate) use poll_state::{PollArray, PollState, PollVec};
 pub(crate) use tuple::{gen_conditions, tuple_len};

--- a/src/utils/pin.rs
+++ b/src/utils/pin.rs
@@ -1,5 +1,6 @@
 use core::pin::Pin;
 use core::slice::SliceIndex;
+use slab::Slab;
 
 // From: `futures_rs::join_all!` -- https://github.com/rust-lang/futures-rs/blob/b48eb2e9a9485ef7388edc2f177094a27e08e28b/futures-util/src/future/join_all.rs#L18-L23
 pub(crate) fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
@@ -19,6 +20,18 @@ pub(crate) fn iter_pin_mut_vec<T>(slice: Pin<&mut Vec<T>>) -> impl Iterator<Item
     unsafe { slice.get_unchecked_mut() }
         .iter_mut()
         .map(|t| unsafe { Pin::new_unchecked(t) })
+}
+
+// From: `futures_rs::join_all!` -- https://github.com/rust-lang/futures-rs/blob/b48eb2e9a9485ef7388edc2f177094a27e08e28b/futures-util/src/future/join_all.rs#L18-L23
+pub(crate) fn iter_pin_mut_slab<T>(
+    slice: Pin<&mut Slab<T>>,
+) -> impl Iterator<Item = (usize, Pin<&mut T>)> {
+    // SAFETY: `std` _could_ make this unsound if it were to decide Pin's
+    // invariants aren't required to transmit through slices. Otherwise this has
+    // the same safety as a normal field pin projection.
+    unsafe { slice.get_unchecked_mut() }
+        .iter_mut()
+        .map(|(index, t)| unsafe { (index, Pin::new_unchecked(t)) })
 }
 
 /// Returns a pinned mutable reference to an element or subslice depending on the


### PR DESCRIPTION
This is similar to `FuturesUnordered` from the futures library, or `JoinSet` from tokio.

# Example

```rust
let mut set = FutureGroup::new();
group.insert(future::ready(2));
group.insert(future::ready(4));

let mut out = 0;
while let Some(num) = group.next().await {
    out += num;
}
assert_eq!(out, 6);
assert_eq!(group.len(), 0);
assert!(set.is_empty());
```

## Tasks
- [x] Initial implementation
- [ ] Make use of an internal `WakerSet` to improve performance
- [x] Figure out a solution to our lending iterator problem