### PR TITLE
Add no-std support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,18 @@ jobs:
         command: check
         args: --all --bins --examples
 
+    - name: check no-std
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --no-default-features
+
+    - name: check alloc
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --no-default-features --features alloc
+
     - name: tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,17 @@ harness = false
 name = "compare"
 harness = false
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = ["bitvec/alloc", "dep:slab", "dep:smallvec"]
+
 [dependencies]
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
-futures-core = "0.3"
+bitvec = { version = "1.0.1", default-features = false }
+futures-core = { version = "0.3", default-features = false }
 pin-project = "1.0.8"
-slab = "0.4.8"
-smallvec = "1.11.0"
+slab = { version = "0.4.8", optional = true }
+smallvec = { version = "1.11.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/benches/utils/countdown_streams.rs
+++ b/benches/utils/countdown_streams.rs
@@ -42,7 +42,7 @@ pub fn streams_array<const N: usize>() -> [CountdownStream; N] {
     let wakers = Rc::new(RefCell::new(BinaryHeap::new()));
     let completed = Rc::new(Cell::new(0));
     let mut streams =
-        std::array::from_fn(|n| CountdownStream::new(n, N, wakers.clone(), completed.clone()));
+        core::array::from_fn(|n| CountdownStream::new(n, N, wakers.clone(), completed.clone()));
     shuffle(&mut streams);
     streams
 }

--- a/src/future/futures_ext.rs
+++ b/src/future/futures_ext.rs
@@ -1,7 +1,7 @@
 use crate::future::Join;
 use crate::future::Race;
+use core::future::IntoFuture;
 use futures_core::Future;
-use std::future::IntoFuture;
 
 use super::join::tuple::Join2;
 use super::race::tuple::Race2;

--- a/src/future/join/mod.rs
+++ b/src/future/join/mod.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Wait for all futures to complete.

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -69,6 +69,7 @@
 //! complete, or return an `Err` if *no* futures complete successfully.
 //!
 #[doc(inline)]
+#[cfg(feature = "alloc")]
 pub use future_group::FutureGroup;
 pub use futures_ext::FutureExt;
 pub use join::Join;
@@ -77,6 +78,7 @@ pub use race_ok::RaceOk;
 pub use try_join::TryJoin;
 
 /// A growable group of futures which act as a single unit.
+#[cfg(feature = "alloc")]
 pub mod future_group;
 
 mod futures_ext;

--- a/src/future/race/array.rs
+++ b/src/future/race/array.rs
@@ -81,7 +81,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::future;
+    use core::future;
 
     // NOTE: we should probably poll in random order.
     #[test]

--- a/src/future/race/mod.rs
+++ b/src/future/race/mod.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Wait for the first future to complete.

--- a/src/future/race/tuple.rs
+++ b/src/future/race/tuple.rs
@@ -106,7 +106,7 @@ impl_race_tuple! { Race12 A B C D E F G H I J K L }
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::future;
+    use core::future;
 
     #[test]
     fn race_1() {

--- a/src/future/race/vec.rs
+++ b/src/future/race/vec.rs
@@ -2,6 +2,7 @@ use crate::utils::{self, Indexer};
 
 use super::Race as RaceTrait;
 
+use alloc::vec::Vec;
 use core::fmt;
 use core::future::{Future, IntoFuture};
 use core::pin::Pin;
@@ -81,7 +82,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::future;
+    use alloc::vec;
+    use core::future;
 
     // NOTE: we should probably poll in random order.
     #[test]

--- a/src/future/race_ok/array/error.rs
+++ b/src/future/race_ok/array/error.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use core::ops::{Deref, DerefMut};
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// A collection of errors.
@@ -14,24 +15,19 @@ impl<E, const N: usize> AggregateError<E, N> {
     }
 }
 
-impl<E: Error, const N: usize> fmt::Debug for AggregateError<E, N> {
+impl<E: fmt::Display, const N: usize> fmt::Debug for AggregateError<E, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{self}:")?;
 
         for (i, err) in self.inner.iter().enumerate() {
             writeln!(f, "- Error {}: {err}", i + 1)?;
-            let mut source = err.source();
-            while let Some(err) = source {
-                writeln!(f, "  ↳ Caused by: {err}")?;
-                source = err.source();
-            }
         }
 
         Ok(())
     }
 }
 
-impl<E: Error, const N: usize> fmt::Display for AggregateError<E, N> {
+impl<E: fmt::Display, const N: usize> fmt::Display for AggregateError<E, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} errors occured", self.inner.len())
     }
@@ -51,4 +47,5 @@ impl<E, const N: usize> DerefMut for AggregateError<E, N> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Error, const N: usize> std::error::Error for AggregateError<E, N> {}

--- a/src/future/race_ok/mod.rs
+++ b/src/future/race_ok/mod.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Wait for the first successful future to complete.

--- a/src/future/race_ok/tuple/error.rs
+++ b/src/future/race_ok/tuple/error.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use core::ops::{Deref, DerefMut};
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// A collection of errors.
@@ -14,6 +15,7 @@ impl<E, const N: usize> AggregateError<E, N> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Error, const N: usize> fmt::Debug for AggregateError<E, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{self}:")?;
@@ -31,7 +33,28 @@ impl<E: Error, const N: usize> fmt::Debug for AggregateError<E, N> {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl<E: fmt::Display, const N: usize> fmt::Debug for AggregateError<E, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{self}:")?;
+
+        for (i, err) in self.inner.iter().enumerate() {
+            writeln!(f, "- Error {}: {err}", i + 1)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
 impl<E: Error, const N: usize> fmt::Display for AggregateError<E, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} errors occured", self.inner.len())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<E: fmt::Display, const N: usize> fmt::Display for AggregateError<E, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} errors occured", self.inner.len())
     }
@@ -51,4 +74,5 @@ impl<E, const N: usize> DerefMut for AggregateError<E, N> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Error, const N: usize> std::error::Error for AggregateError<E, N> {}

--- a/src/future/race_ok/tuple/mod.rs
+++ b/src/future/race_ok/tuple/mod.rs
@@ -178,14 +178,11 @@ impl_race_ok_tuple! { RaceOk12 A B C D E F G H I J K L }
 mod test {
     use super::*;
     use core::future;
-    use std::error::Error;
-
-    type DynError = Box<dyn Error>;
 
     #[test]
     fn race_ok_1() {
         futures_lite::future::block_on(async {
-            let a = async { Ok::<_, DynError>("world") };
+            let a = async { Ok::<_, ()>("world") };
             let res = (a,).race_ok().await;
             assert!(matches!(res, Ok("world")));
         });
@@ -195,7 +192,7 @@ mod test {
     fn race_ok_2() {
         futures_lite::future::block_on(async {
             let a = future::pending();
-            let b = async { Ok::<_, DynError>("world") };
+            let b = async { Ok::<_, ()>("world") };
             let res = (a, b).race_ok().await;
             assert!(matches!(res, Ok("world")));
         });
@@ -205,8 +202,8 @@ mod test {
     fn race_ok_3() {
         futures_lite::future::block_on(async {
             let a = future::pending();
-            let b = async { Ok::<_, DynError>("hello") };
-            let c = async { Ok::<_, DynError>("world") };
+            let b = async { Ok::<_, ()>("hello") };
+            let c = async { Ok::<_, ()>("world") };
             let result = (a, b, c).race_ok().await;
             assert!(matches!(result, Ok("hello") | Ok("world")));
         });

--- a/src/future/race_ok/vec/error.rs
+++ b/src/future/race_ok/vec/error.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
 use core::fmt;
+use core::ops::Deref;
+use core::ops::DerefMut;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::vec::Vec;
 
 /// A collection of errors.
 #[repr(transparent)]
@@ -16,24 +17,19 @@ impl<E> AggregateError<E> {
     }
 }
 
-impl<E: Error> fmt::Debug for AggregateError<E> {
+impl<E: fmt::Display> fmt::Debug for AggregateError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{self}:")?;
 
         for (i, err) in self.inner.iter().enumerate() {
             writeln!(f, "- Error {}: {err}", i + 1)?;
-            let mut source = err.source();
-            while let Some(err) = source {
-                writeln!(f, "  ↳ Caused by: {err}")?;
-                source = err.source();
-            }
         }
 
         Ok(())
     }
 }
 
-impl<E: Error> fmt::Display for AggregateError<E> {
+impl<E: fmt::Display> fmt::Display for AggregateError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} errors occurred", self.inner.len())
     }
@@ -53,4 +49,5 @@ impl<E> DerefMut for AggregateError<E> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Error> Error for AggregateError<E> {}

--- a/src/future/try_join/mod.rs
+++ b/src/future/try_join/mod.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Wait for all futures to complete successfully, or abort early on error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs)]
 #![allow(non_snake_case)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod utils;
 
@@ -95,6 +99,7 @@ pub mod array {
 
 /// Helper functions and types for contiguous growable array type with heap-allocated contents,
 /// written `Vec<T>`.
+#[cfg(feature = "alloc")]
 pub mod vec {
     pub use crate::future::join::vec::Join;
     pub use crate::future::race::vec::Race;

--- a/src/stream/chain/mod.rs
+++ b/src/stream/chain/mod.rs
@@ -2,6 +2,7 @@ use futures_core::Stream;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Takes multiple streams and creates a new stream over all in sequence.

--- a/src/stream/chain/vec.rs
+++ b/src/stream/chain/vec.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -80,6 +81,7 @@ impl<S: Stream> ChainTrait for Vec<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use futures_lite::future::block_on;
     use futures_lite::prelude::*;
     use futures_lite::stream;

--- a/src/stream/merge/mod.rs
+++ b/src/stream/merge/mod.rs
@@ -2,6 +2,7 @@ use futures_core::Stream;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// Combines multiple streams into a single stream of all their outputs.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -52,10 +52,12 @@ pub use into_stream::IntoStream;
 pub use merge::Merge;
 pub use stream_ext::StreamExt;
 #[doc(inline)]
+#[cfg(feature = "alloc")]
 pub use stream_group::StreamGroup;
 pub use zip::Zip;
 
 /// A growable group of streams which act as a single unit.
+#[cfg(feature = "alloc")]
 pub mod stream_group;
 
 pub(crate) mod chain;

--- a/src/stream/zip/array.rs
+++ b/src/stream/zip/array.rs
@@ -4,10 +4,9 @@ use crate::utils::{self, PollArray, WakerArray};
 
 use core::array;
 use core::fmt;
-use core::mem::MaybeUninit;
+use core::mem::{self, MaybeUninit};
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use std::mem;
 
 use futures_core::Stream;
 use pin_project::{pin_project, pinned_drop};
@@ -67,7 +66,7 @@ where
 
         assert!(!*this.done, "Stream should not be polled after completion");
 
-        let mut readiness = this.wakers.readiness().lock().unwrap();
+        let mut readiness = this.wakers.readiness();
         readiness.set_waker(cx.waker());
         for index in 0..N {
             if !readiness.any_ready() {
@@ -94,7 +93,7 @@ where
                     let all_ready = this.state.iter().all(|state| state.is_ready());
                     if all_ready {
                         // Reset the future's state.
-                        readiness = this.wakers.readiness().lock().unwrap();
+                        readiness = this.wakers.readiness();
                         readiness.set_all_ready();
                         this.state.set_all_pending();
 
@@ -118,7 +117,7 @@ where
             }
 
             // Lock readiness so we can use it again
-            readiness = this.wakers.readiness().lock().unwrap();
+            readiness = this.wakers.readiness();
         }
         Poll::Pending
     }

--- a/src/stream/zip/mod.rs
+++ b/src/stream/zip/mod.rs
@@ -2,6 +2,7 @@ use futures_core::Stream;
 
 pub(crate) mod array;
 pub(crate) mod tuple;
+#[cfg(feature = "alloc")]
 pub(crate) mod vec;
 
 /// ‘Zips up’ multiple streams into a single stream of pairs.

--- a/src/stream/zip/tuple.rs
+++ b/src/stream/zip/tuple.rs
@@ -80,7 +80,7 @@ macro_rules! impl_zip_for_tuple {
 
                 assert!(!*this.done, "Stream should not be polled after completion");
 
-                let mut readiness = this.wakers.readiness().lock().unwrap();
+                let mut readiness = this.wakers.readiness();
                 readiness.set_waker(cx.waker());
 
                 for index in 0..LEN {
@@ -126,7 +126,7 @@ macro_rules! impl_zip_for_tuple {
 
                     if all_ready {
                         // Reset the future's state.
-                        readiness = this.wakers.readiness().lock().unwrap();
+                        readiness = this.wakers.readiness();
                         readiness.set_all_ready();
                         this.state.set_all_pending();
 
@@ -147,7 +147,7 @@ macro_rules! impl_zip_for_tuple {
                     }
 
                     // Lock readiness so we can use it again
-                    readiness = this.wakers.readiness().lock().unwrap();
+                    readiness = this.wakers.readiness();
                 }
 
                 Poll::Pending

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -1,4 +1,4 @@
-use std::mem::{self, MaybeUninit};
+use core::mem::{self, MaybeUninit};
 
 /// Extracts the values from an array of `MaybeUninit` containers.
 ///

--- a/src/utils/channel.rs
+++ b/src/utils/channel.rs
@@ -1,8 +1,7 @@
-use std::{
+use alloc::{collections::VecDeque, rc::Rc};
+use core::{
     cell::RefCell,
-    collections::VecDeque,
     pin::Pin,
-    rc::Rc,
     task::{Context, Poll, Waker},
 };
 

--- a/src/utils/futures/array.rs
+++ b/src/utils/futures/array.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     mem::{self, ManuallyDrop, MaybeUninit},
     pin::Pin,
 };

--- a/src/utils/futures/mod.rs
+++ b/src/utils/futures/mod.rs
@@ -1,5 +1,7 @@
 mod array;
+#[cfg(feature = "alloc")]
 mod vec;
 
 pub(crate) use array::FutureArray;
+#[cfg(feature = "alloc")]
 pub(crate) use vec::FutureVec;

--- a/src/utils/futures/vec.rs
+++ b/src/utils/futures/vec.rs
@@ -1,4 +1,5 @@
-use std::{
+use alloc::vec::Vec;
+use core::{
     mem::{self, ManuallyDrop, MaybeUninit},
     pin::Pin,
 };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,18 +9,27 @@ mod poll_state;
 mod tuple;
 mod wakers;
 
-pub(crate) use self::futures::{FutureArray, FutureVec};
+pub(crate) use self::futures::FutureArray;
+#[cfg(feature = "alloc")]
+pub(crate) use self::futures::FutureVec;
 pub(crate) use array::array_assume_init;
 pub(crate) use indexer::Indexer;
-pub(crate) use output::{OutputArray, OutputVec};
-pub(crate) use pin::{get_pin_mut, get_pin_mut_from_vec, iter_pin_mut, iter_pin_mut_vec};
-pub(crate) use poll_state::MaybeDone;
-pub(crate) use poll_state::{PollArray, PollState, PollVec};
+pub(crate) use output::OutputArray;
+#[cfg(feature = "alloc")]
+pub(crate) use output::OutputVec;
+pub(crate) use pin::{get_pin_mut, iter_pin_mut};
+#[cfg(feature = "alloc")]
+pub(crate) use pin::{get_pin_mut_from_vec, iter_pin_mut_vec};
+pub(crate) use poll_state::PollArray;
+#[cfg(feature = "alloc")]
+pub(crate) use poll_state::{MaybeDone, PollState, PollVec};
 pub(crate) use tuple::{gen_conditions, tuple_len};
-pub(crate) use wakers::{WakerArray, WakerVec};
+pub(crate) use wakers::WakerArray;
+#[cfg(feature = "alloc")]
+pub(crate) use wakers::WakerVec;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 pub(crate) use wakers::DummyWaker;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 pub(crate) mod channel;

--- a/src/utils/output/array.rs
+++ b/src/utils/output/array.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     array,
     mem::{self, MaybeUninit},
 };

--- a/src/utils/output/mod.rs
+++ b/src/utils/output/mod.rs
@@ -1,5 +1,7 @@
 mod array;
+#[cfg(feature = "alloc")]
 mod vec;
 
 pub(crate) use array::OutputArray;
+#[cfg(feature = "alloc")]
 pub(crate) use vec::OutputVec;

--- a/src/utils/output/vec.rs
+++ b/src/utils/output/vec.rs
@@ -1,4 +1,6 @@
-use std::mem::{self, MaybeUninit};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::{self, MaybeUninit};
 
 /// A contiguous vector of uninitialized data.
 pub(crate) struct OutputVec<T> {

--- a/src/utils/pin.rs
+++ b/src/utils/pin.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::pin::Pin;
 use core::slice::SliceIndex;
 
@@ -12,6 +14,7 @@ pub(crate) fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<
 }
 
 // From: `futures_rs::join_all!` -- https://github.com/rust-lang/futures-rs/blob/b48eb2e9a9485ef7388edc2f177094a27e08e28b/futures-util/src/future/join_all.rs#L18-L23
+#[cfg(feature = "alloc")]
 pub(crate) fn iter_pin_mut_vec<T>(slice: Pin<&mut Vec<T>>) -> impl Iterator<Item = Pin<&mut T>> {
     // SAFETY: `std` _could_ make this unsound if it were to decide Pin's
     // invariants aren't required to transmit through slices. Otherwise this has
@@ -44,6 +47,7 @@ where
 // slices.
 //
 // From: https://github.com/rust-lang/rust/pull/78370/files
+#[cfg(feature = "alloc")]
 pub(crate) fn get_pin_mut_from_vec<T, I>(
     slice: Pin<&mut Vec<T>>,
     index: I,

--- a/src/utils/poll_state/array.rs
+++ b/src/utils/poll_state/array.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use super::PollState;
 

--- a/src/utils/poll_state/mod.rs
+++ b/src/utils/poll_state/mod.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::module_inception)]
 
 mod array;
+#[cfg(feature = "alloc")]
 mod maybe_done;
 mod poll_state;
+#[cfg(feature = "alloc")]
 mod vec;
 
 pub(crate) use array::PollArray;
+#[cfg(feature = "alloc")]
 pub(crate) use maybe_done::MaybeDone;
 pub(crate) use poll_state::PollState;
+#[cfg(feature = "alloc")]
 pub(crate) use vec::PollVec;

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -1,5 +1,5 @@
+use core::ops::{Deref, DerefMut};
 use smallvec::{smallvec, SmallVec};
-use std::ops::{Deref, DerefMut};
 
 use super::PollState;
 
@@ -24,7 +24,7 @@ use super::PollState;
 ///    len                          ^^^^^
 ///                                 Inline
 /// ```
-const MAX_INLINE_ENTRIES: usize = std::mem::size_of::<usize>() * 3 - 2;
+const MAX_INLINE_ENTRIES: usize = core::mem::size_of::<usize>() * 3 - 2;
 
 #[derive(Default)]
 pub(crate) struct PollVec(SmallVec<[PollState; MAX_INLINE_ENTRIES]>);
@@ -108,8 +108,8 @@ mod tests {
     fn type_size() {
         // PollVec is three words plus two bits
         assert_eq!(
-            std::mem::size_of::<PollVec>(),
-            std::mem::size_of::<usize>() * 4
+            core::mem::size_of::<PollVec>(),
+            core::mem::size_of::<usize>() * 4
         );
     }
 

--- a/src/utils/wakers/array/mod.rs
+++ b/src/utils/wakers/array/mod.rs
@@ -1,7 +1,17 @@
+#[cfg(not(feature = "std"))]
+mod no_std;
+#[cfg(feature = "std")]
 mod readiness_array;
+#[cfg(feature = "std")]
 mod waker;
+#[cfg(feature = "std")]
 mod waker_array;
 
+#[cfg(not(feature = "std"))]
+pub(crate) use no_std::WakerArray;
+#[cfg(feature = "std")]
 pub(crate) use readiness_array::ReadinessArray;
+#[cfg(feature = "std")]
 pub(crate) use waker::InlineWakerArray;
+#[cfg(feature = "std")]
 pub(crate) use waker_array::WakerArray;

--- a/src/utils/wakers/array/no_std.rs
+++ b/src/utils/wakers/array/no_std.rs
@@ -1,0 +1,88 @@
+use core::ops::{Deref, DerefMut};
+use core::task::Waker;
+
+#[derive(Debug)]
+pub(crate) struct ReadinessArray<const N: usize> {
+    parent_waker: Option<Waker>,
+}
+
+impl<const N: usize> ReadinessArray<N> {
+    pub(crate) fn new() -> Self {
+        Self { parent_waker: None }
+    }
+
+    /// Returns the old ready state for this id
+    pub(crate) fn set_ready(&mut self, _id: usize) -> bool {
+        false
+    }
+
+    /// Set all markers to ready.
+    pub(crate) fn set_all_ready(&mut self) {}
+
+    /// Returns whether the task id was previously ready
+    pub(crate) fn clear_ready(&mut self, _id: usize) -> bool {
+        true
+    }
+
+    /// Returns `true` if any of the wakers are ready.
+    pub(crate) fn any_ready(&self) -> bool {
+        true
+    }
+
+    /// Access the parent waker.
+    #[inline]
+    pub(crate) fn parent_waker(&self) -> Option<&Waker> {
+        self.parent_waker.as_ref()
+    }
+
+    /// Set the parent `Waker`. This needs to be called at the start of every
+    /// `poll` function.
+    pub(crate) fn set_waker(&mut self, parent_waker: &Waker) {
+        match &mut self.parent_waker {
+            Some(prev) => prev.clone_from(parent_waker),
+            None => self.parent_waker = Some(parent_waker.clone()),
+        }
+    }
+}
+
+pub(crate) struct ReadinessArrayRef<'a, const N: usize> {
+    inner: &'a mut ReadinessArray<N>,
+}
+
+impl<'a, const N: usize> Deref for ReadinessArrayRef<'a, N> {
+    type Target = ReadinessArray<N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, const N: usize> DerefMut for ReadinessArrayRef<'a, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// A collection of wakers which delegate to an in-line waker.
+pub(crate) struct WakerArray<const N: usize> {
+    readiness: ReadinessArray<N>,
+}
+
+impl<const N: usize> WakerArray<N> {
+    /// Create a new instance of `WakerArray`.
+    pub(crate) fn new() -> Self {
+        let readiness = ReadinessArray::new();
+        Self { readiness }
+    }
+
+    pub(crate) fn get(&self, _index: usize) -> Option<&Waker> {
+        self.readiness.parent_waker()
+    }
+
+    /// Access the `Readiness`.
+    pub(crate) fn readiness(&mut self) -> ReadinessArrayRef<'_, N> {
+        ReadinessArrayRef {
+            inner: &mut self.readiness,
+        }
+    }
+}

--- a/src/utils/wakers/array/readiness_array.rs
+++ b/src/utils/wakers/array/readiness_array.rs
@@ -1,4 +1,4 @@
-use std::task::Waker;
+use core::task::Waker;
 
 /// Tracks which wakers are "ready" and should be polled.
 #[derive(Debug)]

--- a/src/utils/wakers/array/waker.rs
+++ b/src/utils/wakers/array/waker.rs
@@ -1,5 +1,6 @@
-use std::sync::{Arc, Mutex};
-use std::task::Wake;
+use alloc::sync::Arc;
+use alloc::task::Wake;
+use std::sync::Mutex;
 
 use super::ReadinessArray;
 
@@ -18,12 +19,11 @@ impl<const N: usize> InlineWakerArray<N> {
 }
 
 impl<const N: usize> Wake for InlineWakerArray<N> {
-    fn wake(self: std::sync::Arc<Self>) {
+    fn wake(self: Arc<Self>) {
         let mut readiness = self.readiness.lock().unwrap();
         if !readiness.set_ready(self.id) {
             readiness
                 .parent_waker()
-                .as_mut()
                 .expect("`parent_waker` not available from `Readiness`. Did you forget to call `Readiness::set_waker`?")
                 .wake_by_ref()
         }

--- a/src/utils/wakers/array/waker_array.rs
+++ b/src/utils/wakers/array/waker_array.rs
@@ -1,7 +1,7 @@
+use alloc::sync::Arc;
 use core::array;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::task::Waker;
+use core::task::Waker;
+use std::sync::{Mutex, MutexGuard};
 
 use super::{InlineWakerArray, ReadinessArray};
 
@@ -28,7 +28,7 @@ impl<const N: usize> WakerArray<N> {
     }
 
     /// Access the `Readiness`.
-    pub(crate) fn readiness(&self) -> &Mutex<ReadinessArray<N>> {
-        self.readiness.as_ref()
+    pub(crate) fn readiness(&mut self) -> MutexGuard<'_, ReadinessArray<N>> {
+        self.readiness.as_ref().lock().unwrap()
     }
 }

--- a/src/utils/wakers/dummy.rs
+++ b/src/utils/wakers/dummy.rs
@@ -1,4 +1,5 @@
-use std::{sync::Arc, task::Wake};
+use alloc::sync::Arc;
+use alloc::task::Wake;
 
 pub(crate) struct DummyWaker();
 impl Wake for DummyWaker {

--- a/src/utils/wakers/mod.rs
+++ b/src/utils/wakers/mod.rs
@@ -1,10 +1,12 @@
 mod array;
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod dummy;
+#[cfg(feature = "alloc")]
 mod vec;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 pub(crate) use dummy::DummyWaker;
 
 pub(crate) use array::*;
+#[cfg(feature = "alloc")]
 pub(crate) use vec::*;

--- a/src/utils/wakers/vec/mod.rs
+++ b/src/utils/wakers/vec/mod.rs
@@ -1,7 +1,17 @@
+#[cfg(not(feature = "std"))]
+mod no_std;
+#[cfg(feature = "std")]
 mod readiness_vec;
+#[cfg(feature = "std")]
 mod waker;
+#[cfg(feature = "std")]
 mod waker_vec;
 
+#[cfg(not(feature = "std"))]
+pub(crate) use no_std::WakerVec;
+#[cfg(feature = "std")]
 pub(crate) use readiness_vec::ReadinessVec;
+#[cfg(feature = "std")]
 pub(crate) use waker::InlineWakerVec;
+#[cfg(feature = "std")]
 pub(crate) use waker_vec::WakerVec;

--- a/src/utils/wakers/vec/no_std.rs
+++ b/src/utils/wakers/vec/no_std.rs
@@ -1,0 +1,104 @@
+use core::ops::{Deref, DerefMut};
+use core::task::Waker;
+
+#[derive(Debug)]
+pub(crate) struct ReadinessVec {
+    parent_waker: Option<Waker>,
+}
+
+impl ReadinessVec {
+    pub(crate) fn new() -> Self {
+        Self { parent_waker: None }
+    }
+
+    /// Returns the old ready state for this id
+    pub(crate) fn set_ready(&mut self, _id: usize) -> bool {
+        false
+    }
+
+    /// Set all markers to ready.
+    pub(crate) fn set_all_ready(&mut self) {}
+
+    /// Returns whether the task id was previously ready
+    pub(crate) fn clear_ready(&mut self, _id: usize) -> bool {
+        true
+    }
+
+    /// Returns `true` if any of the wakers are ready.
+    pub(crate) fn any_ready(&self) -> bool {
+        true
+    }
+
+    /// Access the parent waker.
+    #[inline]
+    pub(crate) fn parent_waker(&self) -> Option<&Waker> {
+        self.parent_waker.as_ref()
+    }
+
+    /// Set the parent `Waker`. This needs to be called at the start of every
+    /// `poll` function.
+    pub(crate) fn set_waker(&mut self, parent_waker: &Waker) {
+        match &mut self.parent_waker {
+            Some(prev) => prev.clone_from(parent_waker),
+            None => self.parent_waker = Some(parent_waker.clone()),
+        }
+    }
+
+    /// Resize `readiness` to the new length.
+    ///
+    /// If new entries are created, they will be marked as 'ready'.
+    pub(crate) fn resize(&mut self, _len: usize) {}
+}
+
+pub(crate) struct ReadinessVecRef<'a> {
+    inner: &'a mut ReadinessVec,
+}
+
+impl<'a> Deref for ReadinessVecRef<'a> {
+    type Target = ReadinessVec;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a> DerefMut for ReadinessVecRef<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// A collection of wakers which delegate to an in-line waker.
+pub(crate) struct WakerVec {
+    readiness: ReadinessVec,
+}
+
+impl Default for WakerVec {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl WakerVec {
+    /// Create a new instance of `WakerArray`.
+    pub(crate) fn new(_len: usize) -> Self {
+        let readiness = ReadinessVec::new();
+        Self { readiness }
+    }
+
+    pub(crate) fn get(&self, _index: usize) -> Option<&Waker> {
+        self.readiness.parent_waker()
+    }
+
+    /// Access the `Readiness`.
+    pub(crate) fn readiness(&mut self) -> ReadinessVecRef<'_> {
+        ReadinessVecRef {
+            inner: &mut self.readiness,
+        }
+    }
+
+    /// Resize the `WakerVec` to the new size.
+    pub(crate) fn resize(&mut self, len: usize) {
+        self.readiness.resize(len);
+    }
+}

--- a/src/utils/wakers/vec/readiness_vec.rs
+++ b/src/utils/wakers/vec/readiness_vec.rs
@@ -1,5 +1,5 @@
 use bitvec::{bitvec, vec::BitVec};
-use std::task::Waker;
+use core::task::Waker;
 
 /// Tracks which wakers are "ready" and should be polled.
 #[derive(Debug)]

--- a/src/utils/wakers/vec/waker.rs
+++ b/src/utils/wakers/vec/waker.rs
@@ -1,5 +1,6 @@
-use std::sync::{Arc, Mutex};
-use std::task::Wake;
+use alloc::sync::Arc;
+use alloc::task::Wake;
+use std::sync::Mutex;
 
 use super::ReadinessVec;
 
@@ -18,12 +19,11 @@ impl InlineWakerVec {
 }
 
 impl Wake for InlineWakerVec {
-    fn wake(self: std::sync::Arc<Self>) {
+    fn wake(self: Arc<Self>) {
         let mut readiness = self.readiness.lock().unwrap();
         if !readiness.set_ready(self.id) {
             readiness
                 .parent_waker()
-                .as_mut()
                 .expect("`parent_waker` not available from `Readiness`. Did you forget to call `Readiness::set_waker`?")
                 .wake_by_ref()
         }

--- a/src/utils/wakers/vec/waker_vec.rs
+++ b/src/utils/wakers/vec/waker_vec.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::task::Waker;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::task::Waker;
+use std::sync::{Mutex, MutexGuard};
 
 use super::{InlineWakerVec, ReadinessVec};
 
@@ -31,8 +32,8 @@ impl WakerVec {
     }
 
     /// Access the `Readiness`.
-    pub(crate) fn readiness(&self) -> &Mutex<ReadinessVec> {
-        self.readiness.as_ref()
+    pub(crate) fn readiness(&self) -> MutexGuard<'_, ReadinessVec> {
+        self.readiness.lock().unwrap()
     }
 
     /// Resize the `WakerVec` to the new size.

--- a/tests/regression-155.rs
+++ b/tests/regression-155.rs
@@ -4,6 +4,8 @@
 //! path. This meant that when we returned, the destructor assumed a value was
 //! initialized when it wasn't, causing it to dereference uninitialized memory.
 
+#![cfg(feature = "alloc")]
+
 use futures_concurrency::prelude::*;
 use futures_core::Future;
 use std::{future::ready, pin::Pin};


### PR DESCRIPTION
Adds `std` and `alloc` features to enable support for no-std targets.

Mostly this was just a matter of updating imports from `std` to `core` or `alloc` as necessary along with `cfg` directives to omit things like the vec implementations that require an allocator.

The only real issue I ran into was that the implementations of `WakerArray` and `WakerVec` required both `Arc` and `Mutex`. `Arc` is only available on `alloc` and `Mutex` is only available on `std`. So I've added very basic no-std implementations of both which simply revert to using the parent waker directly instead of trying to do precise waking. I think it should be possible to implement precise waking in a no-std environment, but will require messing with `RawWakers` and probably pinning and a fair amount of unsafe code. This does mean that on no-std targets all futures will be polled on every wake.

The only other behavior difference is removing printing of the child error sources in the `Debug` impl of the `AggregateError` structs. This was necessary because the `Error` trait is currently std only. It does have the side benefit of there now being a `Debug` impl for any `AggregateError` whose `T` impls `Display` instead of only when `T` impls `Error`.

I updated CI to run `cargo check` on std, alloc, and core configurations. Let me know if you want CI to run `cargo test` on the no-std configurations as well.