### PR TITLE
fix insertion performance issues for our `Group` structures

### DIFF
--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -231,9 +231,12 @@ impl<F: Future> FutureGroup<F> {
 
         // If our slab allocated more space we need to
         // update our tracking structures along with it.
-        let max_len = self.capacity().max(index);
-        self.wakers.resize(max_len);
-        self.states.resize(max_len);
+        let capacity = self.capacity();
+        let max_len = capacity.max(index);
+        if max_len > capacity {
+            self.wakers.resize(max_len);
+            self.states.resize(max_len);
+        }
 
         // Set the corresponding state
         self.states[index].set_pending();

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -226,9 +226,8 @@ impl<S: Stream> StreamGroup<S> {
     where
         S: Stream,
     {
-        dbg!();
         let index = self.streams.insert(stream);
-        self.keys.insert(dbg!(index));
+        self.keys.insert(index);
         let key = Key(index);
 
         // If our slab allocated more space we need to

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -66,6 +66,7 @@ pub struct StreamGroup<S> {
     states: PollVec,
     keys: BTreeSet<usize>,
     key_removal_queue: SmallVec<[usize; 10]>,
+    capacity: usize,
 }
 
 impl<T: Debug> Debug for StreamGroup<T> {
@@ -108,6 +109,7 @@ impl<S> StreamGroup<S> {
             states: PollVec::new(capacity),
             keys: BTreeSet::new(),
             key_removal_queue: smallvec![],
+            capacity,
         }
     }
 
@@ -141,7 +143,7 @@ impl<S> StreamGroup<S> {
     /// # let group: StreamGroup<usize> = group;
     /// ```
     pub fn capacity(&self) -> usize {
-        self.streams.capacity()
+        self.capacity
     }
 
     /// Returns true if there are no futures currently active in the group.
@@ -224,17 +226,19 @@ impl<S: Stream> StreamGroup<S> {
     where
         S: Stream,
     {
+        dbg!();
         let index = self.streams.insert(stream);
-        self.keys.insert(index);
+        self.keys.insert(dbg!(index));
         let key = Key(index);
 
         // If our slab allocated more space we need to
         // update our tracking structures along with it.
         let capacity = self.capacity();
-        let max_len = capacity.max(index);
+        let max_len = capacity.max(index + 1);
         if max_len > capacity {
             self.wakers.resize(max_len);
             self.states.resize(max_len);
+            self.capacity = max_len;
         }
 
         // Set the corresponding state
@@ -441,6 +445,16 @@ mod test {
             assert_eq!(out, 6);
             assert_eq!(group.len(), 0);
             assert!(group.is_empty());
+        });
+    }
+
+    #[test]
+    fn insert_many() {
+        futures_lite::future::block_on(async {
+            let mut group = StreamGroup::new();
+            for _ in 0..100 {
+                group.insert(stream::once(2));
+            }
         });
     }
 }

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -230,9 +230,12 @@ impl<S: Stream> StreamGroup<S> {
 
         // If our slab allocated more space we need to
         // update our tracking structures along with it.
-        let max_len = self.capacity().max(index);
-        self.wakers.resize(max_len);
-        self.states.resize(max_len);
+        let capacity = self.capacity();
+        let max_len = capacity.max(index);
+        if max_len > capacity {
+            self.wakers.resize(max_len);
+            self.states.resize(max_len);
+        }
 
         // Set the corresponding state
         self.states[index].set_pending();


### PR DESCRIPTION
https://github.com/smol-rs/futures-lite/issues/93#issuecomment-2005364297 showed a performance issue with `FutureGroup`. The issue turned out to be related to the `bitvec` crate performing really poorly if `resize` was called trivially. By instead guarding against calls to `resize` this issue goes away entirely.

This did not show up in our benchmarks because never exercised `insert` as part of the actual benchmark; we factored it out as part of the test setup. This is theoretically more "correct", but it also didn't surface the issue. We should probably consider adding end-to-end benchmarks for all of our operations too to catch any potential issues elsewhere. Especially for our `Group` structures. Thanks!

## Benchmark results

Using the benchmarks authored by @notgull in [this repo](https://github.com/notgull/futures-concurrency-benchmark), running for 10.000 times (rather than 1 million):

**before**
```text
group/futures_concurrency::FutureGroup
                        time:   [2.5047 ms 2.5065 ms 2.5082 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
```

**after**
```text
     Running benches/co.rs (target/release/deps/co-71ce600071789f52)
group/futures_concurrency::FutureGroup
                        time:   [672.93 µs 675.00 µs 678.70 µs]
                        change: [-73.137% -73.055% -72.953%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```