### PR TITLE
Better capacity and growth rate for `{Stream,Future}Group`

### DIFF
--- a/src/collections/group_inner.rs
+++ b/src/collections/group_inner.rs
@@ -48,7 +48,7 @@ impl<A> GroupInner<A> {
 
     pub fn insert(&mut self, item: A) -> Key {
         if !self.has_capacity() {
-            self.resize(self.cap + 1 * GROUP_GROWTH_FACTOR);
+            self.resize((self.cap + 1) * GROUP_GROWTH_FACTOR);
         }
 
         let index = self.items.insert(item);
@@ -65,7 +65,7 @@ impl<A> GroupInner<A> {
     pub fn insert_pinned(mut self: Pin<&mut Self>, item: A) -> Key {
         if !self.has_capacity() {
             let r = unsafe { &mut self.as_mut().get_unchecked_mut() };
-            r.resize(r.cap + 1 * GROUP_GROWTH_FACTOR);
+            r.resize((r.cap + 1) * GROUP_GROWTH_FACTOR);
         }
 
         let mut this = self.project();

--- a/src/collections/group_inner.rs
+++ b/src/collections/group_inner.rs
@@ -1,0 +1,144 @@
+use core::{pin::Pin, task::Waker};
+
+use alloc::{collections::BTreeSet, fmt};
+use slab::Slab;
+
+use crate::utils::{PollVec, WakerVec};
+
+const GROUP_GROWTH_FACTOR: usize = 2;
+
+#[pin_project::pin_project]
+pub struct GroupInner<A> {
+    #[pin]
+    pub items: Slab<A>,
+    pub wakers: WakerVec,
+    pub states: PollVec,
+    pub keys: BTreeSet<usize>,
+    cap: usize,
+    len: usize,
+}
+
+impl<A> GroupInner<A> {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            items: Slab::with_capacity(cap),
+            wakers: WakerVec::new(cap),
+            states: PollVec::new(cap),
+            keys: BTreeSet::new(),
+            cap,
+            len: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
+    pub fn has_capacity(&self) -> bool {
+        self.len < self.cap
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn insert(&mut self, item: A) -> Key {
+        if !self.has_capacity() {
+            self.resize(self.cap + 1 * GROUP_GROWTH_FACTOR);
+        }
+
+        let index = self.items.insert(item);
+        self.keys.insert(index);
+
+        // set the corresponding state
+        self.states[index].set_pending();
+        self.wakers.readiness().set_ready(index);
+
+        self.len += 1;
+        Key(index)
+    }
+
+    pub fn insert_pinned(mut self: Pin<&mut Self>, item: A) -> Key {
+        if !self.has_capacity() {
+            let r = unsafe { &mut self.as_mut().get_unchecked_mut() };
+            r.resize(r.cap + 1 * GROUP_GROWTH_FACTOR);
+        }
+
+        let mut this = self.project();
+        let items = unsafe { &mut this.items.as_mut().get_unchecked_mut() };
+        let index = items.insert(item);
+        this.keys.insert(index);
+
+        // set the corresponding state
+        this.states[index].set_pending();
+        this.wakers.readiness().set_ready(index);
+
+        *this.len += 1;
+        Key(index)
+    }
+
+    pub fn remove(&mut self, key: Key) -> Option<A> {
+        let is_present = self.keys.remove(&key.0);
+        if !is_present {
+            return None;
+        }
+        self.states[key.0].set_none();
+        let item = self.items.remove(key.0);
+        self.len -= 1;
+        Some(item)
+    }
+
+    // todo: rename to reserve
+    pub fn resize(&mut self, cap: usize) {
+        if self.len + cap < self.cap {
+            return;
+        }
+        self.wakers.resize(cap);
+        self.states.resize(cap);
+        self.items.reserve_exact(cap);
+        self.cap = cap;
+    }
+
+    pub fn any_ready(&self) -> bool {
+        self.wakers.readiness().any_ready()
+    }
+
+    pub fn set_top_waker(&mut self, waker: &Waker) {
+        self.wakers.readiness().set_waker(waker);
+    }
+
+    pub fn can_progress_index(&self, index: usize) -> bool {
+        self.states[index].is_pending() && self.wakers.readiness().clear_ready(index)
+    }
+}
+
+/// Keyed operations
+impl<A> GroupInner<A> {
+    // move to other impl block
+    pub fn contains_key(&self, key: Key) -> bool {
+        self.items.contains(key.0)
+    }
+}
+
+impl<A> Default for GroupInner<A> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<A> fmt::Debug for GroupInner<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupInner")
+            .field("cap", &self.cap)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+/// A key used to index into the `FutureGroup` type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Key(pub usize);

--- a/src/collections/inner_group.rs
+++ b/src/collections/inner_group.rs
@@ -8,7 +8,7 @@ use crate::utils::{PollVec, WakerVec};
 const GROUP_GROWTH_FACTOR: usize = 2;
 
 #[pin_project::pin_project]
-pub struct GroupInner<A> {
+pub struct InnerGroup<A> {
     #[pin]
     pub items: Slab<A>,
     pub wakers: WakerVec,
@@ -18,7 +18,7 @@ pub struct GroupInner<A> {
     len: usize,
 }
 
-impl<A> GroupInner<A> {
+impl<A> InnerGroup<A> {
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             items: Slab::with_capacity(cap),
@@ -117,20 +117,20 @@ impl<A> GroupInner<A> {
 }
 
 /// Keyed operations
-impl<A> GroupInner<A> {
+impl<A> InnerGroup<A> {
     // move to other impl block
     pub fn contains_key(&self, key: Key) -> bool {
         self.items.contains(key.0)
     }
 }
 
-impl<A> Default for GroupInner<A> {
+impl<A> Default for InnerGroup<A> {
     fn default() -> Self {
         Self::with_capacity(0)
     }
 }
 
-impl<A> fmt::Debug for GroupInner<A> {
+impl<A> fmt::Debug for InnerGroup<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GroupInner")
             .field("cap", &self.cap)

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 pub(crate) mod inner_group;
 #[cfg(feature = "alloc")]
 pub mod vec;

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod group_inner;
 #[cfg(feature = "alloc")]
 pub mod vec;

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod group_inner;
+pub(crate) mod inner_group;
 #[cfg(feature = "alloc")]
 pub mod vec;

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -55,11 +56,26 @@ use crate::collections::inner_group::{InnerGroup, Key, PollFuture};
 /// # });}
 /// ```
 #[must_use = "`FutureGroup` does nothing if not iterated over"]
-#[derive(Debug)]
 #[pin_project::pin_project]
 pub struct FutureGroup<F> {
     #[pin]
     inner: InnerGroup<F, PollFuture>,
+}
+
+impl<F> Default for FutureGroup<F> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for FutureGroup<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FutureGroup")
+            .field("slab", &"[..]")
+            .field("len", &self.inner.len())
+            .field("capacity", &self.inner.capacity())
+            .finish()
+    }
 }
 
 impl<F> FutureGroup<F> {
@@ -203,12 +219,6 @@ impl<F> FutureGroup<F> {
     /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.inner.reserve(additional);
-    }
-}
-
-impl<F> Default for FutureGroup<F> {
-    fn default() -> Self {
-        Self::with_capacity(0)
     }
 }
 

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -186,6 +186,25 @@ impl<F> FutureGroup<F> {
     pub fn contains_key(&mut self, key: Key) -> bool {
         self.inner.contains_key(key)
     }
+
+    /// Reserves capacity for `additional` more futures to be inserted.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use futures_concurrency::future::FutureGroup;
+    /// use std::future;
+    /// # futures_lite::future::block_on(async {
+    /// let mut group = FutureGroup::with_capacity(0);
+    /// assert_eq!(group.capacity(), 0);
+    /// group.reserve(10);
+    /// assert_eq!(group.capacity(), 10);
+    /// # })
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
 }
 
 impl<F> Default for FutureGroup<F> {

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -4,7 +4,7 @@ use core::task::{Context, Poll};
 use futures_core::stream::Stream;
 use futures_core::Future;
 
-use crate::collections::group_inner::{GroupInner, Key};
+use crate::collections::inner_group::{InnerGroup, Key};
 
 /// A growable group of futures which act as a single unit.
 ///
@@ -59,7 +59,7 @@ use crate::collections::group_inner::{GroupInner, Key};
 #[pin_project::pin_project]
 pub struct FutureGroup<F> {
     #[pin]
-    inner: GroupInner<F>,
+    inner: InnerGroup<F>,
 }
 
 impl<F> FutureGroup<F> {
@@ -89,7 +89,7 @@ impl<F> FutureGroup<F> {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: GroupInner::with_capacity(capacity),
+            inner: InnerGroup::with_capacity(capacity),
         }
     }
 

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -75,7 +75,7 @@ impl<F> FutureGroup<F> {
     /// # let group: FutureGroup<core::future::Ready<usize>> = group;
     /// ```
     pub fn new() -> Self {
-        Self::with_capacity(0)
+        Self::default()
     }
 
     /// Create a new instance of `FutureGroup` with a given capacity.
@@ -185,6 +185,12 @@ impl<F> FutureGroup<F> {
     /// ```
     pub fn contains_key(&mut self, key: Key) -> bool {
         self.inner.contains_key(key)
+    }
+}
+
+impl<F> Default for FutureGroup<F> {
+    fn default() -> Self {
+        Self::with_capacity(0)
     }
 }
 

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -5,7 +5,7 @@ use futures_core::stream::Stream;
 use futures_core::Future;
 
 use crate::collections::inner_group::theory::PollFuture;
-use crate::collections::inner_group::{Group, InnerGroup, Key};
+use crate::collections::inner_group::{InnerGroup, Key};
 
 /// A growable group of futures which act as a single unit.
 ///
@@ -58,12 +58,12 @@ use crate::collections::inner_group::{Group, InnerGroup, Key};
 #[must_use = "`FutureGroup` does nothing if not iterated over"]
 #[derive(Debug)]
 #[pin_project::pin_project]
-pub struct FutureGroup<F: Future> {
+pub struct FutureGroup<F> {
     #[pin]
-    inner: Group<F, PollFuture<F>>,
+    inner: InnerGroup<F, PollFuture<F>>,
 }
 
-impl<F: Future> FutureGroup<F> {
+impl<F> FutureGroup<F> {
     /// Create a new instance of `FutureGroup`.
     ///
     /// # Example
@@ -90,10 +90,7 @@ impl<F: Future> FutureGroup<F> {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: Group {
-                inner: InnerGroup::with_capacity(capacity),
-                _poll_behavior: core::marker::PhantomData,
-            },
+            inner: InnerGroup::with_capacity(capacity),
         }
     }
 
@@ -112,7 +109,7 @@ impl<F: Future> FutureGroup<F> {
     /// assert_eq!(group.len(), 1);
     /// ```
     pub fn len(&self) -> usize {
-        self.inner.inner.len()
+        self.inner.len()
     }
 
     /// Return the capacity of the `FutureGroup`.
@@ -128,7 +125,7 @@ impl<F: Future> FutureGroup<F> {
     /// # let group: FutureGroup<core::future::Ready<usize>> = group;
     /// ```
     pub fn capacity(&self) -> usize {
-        self.inner.inner.capacity()
+        self.inner.capacity()
     }
 
     /// Returns true if there are no futures currently active in the group.
@@ -145,7 +142,7 @@ impl<F: Future> FutureGroup<F> {
     /// assert!(!group.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.inner.inner.is_empty()
+        self.inner.is_empty()
     }
 
     /// Removes a stream from the group. Returns whether the value was present in
@@ -167,7 +164,7 @@ impl<F: Future> FutureGroup<F> {
     /// ```
     pub fn remove(&mut self, key: Key) -> bool {
         // TODO(consoli): is it useful to return the removed future here?
-        self.inner.inner.remove(key).is_some()
+        self.inner.remove(key).is_some()
     }
 
     /// Returns `true` if the `FutureGroup` contains a value for the specified key.
@@ -187,7 +184,7 @@ impl<F: Future> FutureGroup<F> {
     /// # })
     /// ```
     pub fn contains_key(&mut self, key: Key) -> bool {
-        self.inner.inner.contains_key(key)
+        self.inner.contains_key(key)
     }
 }
 
@@ -207,7 +204,7 @@ impl<F: Future> FutureGroup<F> {
     where
         F: Future,
     {
-        self.inner.inner.insert(future)
+        self.inner.insert(future)
     }
 
     /// Insert a value into a pinned `FutureGroup`
@@ -217,16 +214,8 @@ impl<F: Future> FutureGroup<F> {
     /// point of this crate is that we abstract the futures poll machinery away
     /// from end-users.
     pub(crate) fn insert_pinned(self: Pin<&mut Self>, future: F) -> Key {
-        let mut this = self.project();
-        let inner = unsafe {
-            this.inner
-                .as_mut()
-                .map_unchecked_mut(|inner| &mut inner.inner)
-        };
-        inner.insert_pinned(future)
-
-        // let inner = unsafe { self.as_mut().map_unchecked_mut(|this| &mut this.inner) };
-        // inner.insert_pinned(future)
+        let this = self.project();
+        this.inner.insert_pinned(future)
     }
 
     /// Create a stream which also yields the key of each item.
@@ -256,60 +245,12 @@ impl<F: Future> FutureGroup<F> {
     }
 }
 
-// impl<F: Future> FutureGroup<F> {
-//     fn poll_next_inner(
-//         self: Pin<&mut Self>,
-//         cx: &Context<'_>,
-//     ) -> Poll<Option<(Key, <F as Future>::Output)>> {
-//         let mut this = self.project();
-//         let inner = unsafe { &mut this.inner.as_mut().get_unchecked_mut() };
-
-//         // Short-circuit if we have no futures to iterate over
-//         if inner.is_empty() {
-//             return Poll::Ready(None);
-//         }
-
-//         // Set the top-level waker and check readiness
-//         inner.set_top_waker(cx.waker());
-//         if !inner.any_ready() {
-//             // Nothing is ready yet
-//             return Poll::Pending;
-//         }
-
-//         for index in inner.keys.iter().cloned() {
-//             // verify if the `index`th future can be polled
-//             if !inner.can_progress_index(index) {
-//                 continue;
-//             }
-
-//             // Obtain the intermediate waker.
-//             let mut cx = Context::from_waker(inner.wakers.get(index).unwrap());
-
-//             // SAFETY: this future here is a projection from the futures
-//             // vec, which we're reading from.
-//             let future = unsafe { Pin::new_unchecked(&mut inner.items[index]) };
-//             if let Poll::Ready(item) = future.poll(&mut cx) {
-//                 let key = Key(index);
-//                 // Set the return type for the function
-//                 let ret = Poll::Ready(Some((key, item)));
-
-//                 // Remove all associated data with the future
-//                 // The only data we can't remove directly is the key entry.
-//                 inner.remove(key);
-
-//                 return ret;
-//             }
-//         }
-//         Poll::Pending
-//     }
-// }
-
 impl<F: Future> Stream for FutureGroup<F> {
     type Item = <F as Future>::Output;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let pinned = unsafe { self.as_mut().map_unchecked_mut(|this| &mut this.inner) };
-        match pinned.poll_next_inner(cx) {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.inner.poll_next_inner(cx) {
             Poll::Ready(Some((_key, item))) => Poll::Ready(Some(item)),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -355,14 +296,8 @@ impl<F: Future> Stream for Keyed<F> {
     type Item = (Key, <F as Future>::Output);
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // let mut this = self.project();
-        // this.group.as_mut().poll_next_inner(cx)
         let mut this = self.project();
-        let inner = unsafe {
-            this.group
-                .as_mut()
-                .map_unchecked_mut(|inner| &mut inner.inner)
-        };
+        let inner = unsafe { this.group.as_mut().map_unchecked_mut(|t| &mut t.inner) };
         inner.poll_next_inner(cx)
     }
 }

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -4,8 +4,7 @@ use core::task::{Context, Poll};
 use futures_core::stream::Stream;
 use futures_core::Future;
 
-use crate::collections::inner_group::theory::PollFuture;
-use crate::collections::inner_group::{InnerGroup, Key};
+use crate::collections::inner_group::{InnerGroup, Key, PollFuture};
 
 /// A growable group of futures which act as a single unit.
 ///
@@ -60,7 +59,7 @@ use crate::collections::inner_group::{InnerGroup, Key};
 #[pin_project::pin_project]
 pub struct FutureGroup<F> {
     #[pin]
-    inner: InnerGroup<F, PollFuture<F>>,
+    inner: InnerGroup<F, PollFuture>,
 }
 
 impl<F> FutureGroup<F> {

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -194,9 +194,9 @@ impl<F> FutureGroup<F> {
     ///
     /// ```rust
     /// use futures_concurrency::future::FutureGroup;
-    /// use std::future;
+    /// use std::future::Ready;
     /// # futures_lite::future::block_on(async {
-    /// let mut group = FutureGroup::with_capacity(0);
+    /// let mut group: FutureGroup<Ready<usize>> = FutureGroup::with_capacity(0);
     /// assert_eq!(group.capacity(), 0);
     /// group.reserve(10);
     /// assert_eq!(group.capacity(), 10);

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -183,6 +183,25 @@ impl<S> StreamGroup<S> {
     pub fn contains_key(&mut self, key: Key) -> bool {
         self.inner.contains_key(key)
     }
+
+    /// Reserves capacity for `additional` more streams to be inserted.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use futures_concurrency::future::StreamGroup;
+    /// use std::future;
+    /// # futures_lite::future::block_on(async {
+    /// let mut group = StreamGroup::with_capacity(0);
+    /// assert_eq!(group.capacity(), 0);
+    /// group.reserve(10);
+    /// assert_eq!(group.capacity(), 10);
+    /// # })
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
 }
 
 impl<S: Stream> StreamGroup<S> {

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -190,10 +190,10 @@ impl<S> StreamGroup<S> {
     /// # Example
     ///
     /// ```rust
-    /// use futures_concurrency::future::StreamGroup;
-    /// use std::future;
+    /// use futures_concurrency::stream::StreamGroup;
+    /// use futures_lite::stream::Once;
     /// # futures_lite::future::block_on(async {
-    /// let mut group = StreamGroup::with_capacity(0);
+    /// let mut group: StreamGroup<Once<usize>> = StreamGroup::with_capacity(0);
     /// assert_eq!(group.capacity(), 0);
     /// group.reserve(10);
     /// assert_eq!(group.capacity(), 10);

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -3,8 +3,8 @@ use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures_core::Stream;
-use smallvec::{smallvec, SmallVec};
 
+use crate::collections::inner_group::theory::PollStream;
 use crate::collections::inner_group::{InnerGroup, Key};
 
 /// A growable group of streams which act as a single unit.
@@ -59,7 +59,7 @@ use crate::collections::inner_group::{InnerGroup, Key};
 #[pin_project::pin_project]
 pub struct StreamGroup<S> {
     #[pin]
-    inner: InnerGroup<S>,
+    inner: InnerGroup<S, PollStream<S>>,
 }
 
 impl<S> StreamGroup<S> {
@@ -230,94 +230,12 @@ impl<S: Stream> StreamGroup<S> {
     }
 }
 
-impl<S: Stream> StreamGroup<S> {
-    fn poll_next_inner(
-        self: Pin<&mut Self>,
-        cx: &Context<'_>,
-    ) -> Poll<Option<(Key, <S as Stream>::Item)>> {
-        let mut this = self.project();
-        let inner = unsafe { &mut this.inner.as_mut().get_unchecked_mut() };
-
-        // Short-circuit if we have no streams to iterate over
-        if inner.is_empty() {
-            return Poll::Ready(None);
-        }
-
-        // Set the top-level waker and check readiness
-        inner.set_top_waker(cx.waker());
-        if !inner.any_ready() {
-            // Nothing is ready yet
-            return Poll::Pending;
-        }
-
-        // Setup our stream state
-        let mut done_count = 0;
-        let stream_count = inner.len();
-        let mut removal_queue: SmallVec<[usize; 10]> = smallvec![];
-
-        for index in inner.keys.iter().cloned() {
-            if !inner.can_progress_index(index) {
-                continue;
-            }
-
-            // Obtain the intermediate waker.
-            let mut cx = Context::from_waker(inner.wakers.get(index).unwrap());
-
-            // SAFETY: this stream here is a projection from the streams
-            // vec, which we're reading from.
-            let stream = unsafe { Pin::new_unchecked(&mut inner.items[index]) };
-            match stream.poll_next(&mut cx) {
-                Poll::Ready(Some(item)) => {
-                    let key = Key(index);
-                    // Set the return type for the function
-                    let ret = Poll::Ready(Some((key, item)));
-
-                    // We just obtained an item from this index, make sure
-                    // we check it again on a next iteration
-                    inner.states[index].set_pending();
-                    inner.wakers.readiness().set_ready(index);
-
-                    for key in removal_queue {
-                        inner.remove(Key(key));
-                    }
-
-                    return ret;
-                }
-                Poll::Ready(None) => {
-                    // A stream has ended, make note of that
-                    done_count += 1;
-
-                    // Remove all associated data about the stream.
-                    // The only data we can't remove directly is the key entry.
-                    removal_queue.push(index);
-                    continue;
-                }
-                // Keep looping if there is nothing for us to do
-                Poll::Pending => {}
-            };
-        }
-
-        // Now that we're no longer borrowing `this.keys` we can loop over
-        // which items we need to remove
-        for key in removal_queue {
-            inner.remove(Key(key));
-        }
-
-        // If all streams turned up with `Poll::Ready(None)` our
-        // stream should return that
-        if done_count == stream_count {
-            return Poll::Ready(None);
-        }
-
-        Poll::Pending
-    }
-}
-
 impl<S: Stream> Stream for StreamGroup<S> {
     type Item = <S as Stream>::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.poll_next_inner(cx) {
+        let this = self.project();
+        match this.inner.poll_next_inner(cx) {
             Poll::Ready(Some((_key, item))) => Poll::Ready(Some(item)),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -364,7 +282,9 @@ impl<S: Stream> Stream for Keyed<S> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
-        this.group.as_mut().poll_next_inner(cx)
+        // todo: unsafe
+        let inner = unsafe { this.group.as_mut().map_unchecked_mut(|t| &mut t.inner) };
+        inner.poll_next_inner(cx)
     }
 }
 

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -5,7 +5,7 @@ use core::task::{Context, Poll};
 use futures_core::Stream;
 use smallvec::{smallvec, SmallVec};
 
-use crate::collections::group_inner::{GroupInner, Key};
+use crate::collections::inner_group::{InnerGroup, Key};
 
 /// A growable group of streams which act as a single unit.
 ///
@@ -59,7 +59,7 @@ use crate::collections::group_inner::{GroupInner, Key};
 #[pin_project::pin_project]
 pub struct StreamGroup<S> {
     #[pin]
-    inner: GroupInner<S>,
+    inner: InnerGroup<S>,
 }
 
 impl<S> StreamGroup<S> {
@@ -89,7 +89,7 @@ impl<S> StreamGroup<S> {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: GroupInner::with_capacity(capacity),
+            inner: InnerGroup::with_capacity(capacity),
         }
     }
 

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -1,4 +1,4 @@
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -54,11 +54,26 @@ use crate::collections::inner_group::{InnerGroup, Key, PollStream};
 /// # });
 /// ```
 #[must_use = "`StreamGroup` does nothing if not iterated over"]
-#[derive(Default, Debug)]
 #[pin_project::pin_project]
 pub struct StreamGroup<S> {
     #[pin]
     inner: InnerGroup<S, PollStream>,
+}
+
+impl<F> Default for StreamGroup<F> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for StreamGroup<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StreamGroup")
+            .field("slab", &"[..]")
+            .field("len", &self.inner.len())
+            .field("capacity", &self.inner.capacity())
+            .finish()
+    }
 }
 
 impl<S> StreamGroup<S> {

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -300,7 +300,8 @@ impl<S: Stream> Stream for Keyed<S> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
-        // todo: unsafe
+        // SAFETY: pin-projecting to the inner group is safe because we trust
+        // it that it's correctly pinned
         let inner = unsafe { this.group.as_mut().map_unchecked_mut(|t| &mut t.inner) };
         inner.poll_next_inner(cx)
     }

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -4,8 +4,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures_core::Stream;
 
-use crate::collections::inner_group::theory::PollStream;
-use crate::collections::inner_group::{InnerGroup, Key};
+use crate::collections::inner_group::{InnerGroup, Key, PollStream};
 
 /// A growable group of streams which act as a single unit.
 ///
@@ -59,7 +58,7 @@ use crate::collections::inner_group::{InnerGroup, Key};
 #[pin_project::pin_project]
 pub struct StreamGroup<S> {
     #[pin]
-    inner: InnerGroup<S, PollStream<S>>,
+    inner: InnerGroup<S, PollStream>,
 }
 
 impl<S> StreamGroup<S> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use pin::{get_pin_mut, iter_pin_mut};
 pub(crate) use pin::{get_pin_mut_from_vec, iter_pin_mut_vec};
 pub(crate) use poll_state::PollArray;
 #[cfg(feature = "alloc")]
-pub(crate) use poll_state::{MaybeDone, PollState, PollVec};
+pub(crate) use poll_state::{MaybeDone, PollVec};
 pub(crate) use tuple::{gen_conditions, tuple_len};
 pub(crate) use wakers::WakerArray;
 #[cfg(feature = "alloc")]

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -26,7 +26,7 @@ use super::PollState;
 /// ```
 const MAX_INLINE_ENTRIES: usize = core::mem::size_of::<usize>() * 3 - 2;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct PollVec(SmallVec<[PollState; MAX_INLINE_ENTRIES]>);
 
 impl PollVec {


### PR DESCRIPTION
Fixes the same problem as #168 by keeping up with the capacity and growth rate of the group.

When a group tries to grow over its capacity, we double the previous capacity.

`FutureGroup` and `StreamGroup` are structurally very similar, they only differ on the `Stream` implementation, so I isolated the common structure to reduce the duplicated code.

## Performance

Compared to the main branch, we gained 99,775% using [this benchmark](https://github.com/notgull/futures-concurrency-benchmark) (with 1_000_000 futures).

Before:
```rust
group/futures_concurrency::FutureGroup
                        time:   [27.222 s 28.561 s 29.720 s]
```


After:

```rust
group/futures_concurrency::FutureGroup
                        time:   [68.507 ms 68.598 ms 68.752 ms]
                        change: [-99.769% -99.760% -99.748%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## todos
- [x] make `FutureGroup` and `StreamGroup` type aliases for a common struct generic over the poll behavior
- [x] rename `resize` to `reserve` and expose it
- [x] tests and docs and benchmarks?

Closes #169

