### PR TITLE
add new benchmark for `FutureGroup`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ criterion = { version = "0.3", features = [
 ] }
 futures = "0.3.25"
 futures-time = "3.0.0"
+itertools = "0.12.1"
 lending-stream = "1.0.0"
 rand = "0.8.5"
 tokio = { version = "1.32.0", features = ["macros", "time", "rt-multi-thread"] }

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -415,14 +415,22 @@ impl<F: Future> Stream for FutureGroup<F> {
     }
 }
 
-impl<F: Future> FromIterator<F> for FutureGroup<F> {
-    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
+impl<F: Future> Extend<F> for FutureGroup<F> {
+    fn extend<T: IntoIterator<Item = F>>(&mut self, iter: T) {
         let iter = iter.into_iter();
         let len = iter.size_hint().1.unwrap_or_default();
-        let mut this = Self::with_capacity(len);
+        self.reserve(len);
+
         for future in iter {
-            this.insert(future);
+            self.insert(future);
         }
+    }
+}
+
+impl<F: Future> FromIterator<F> for FutureGroup<F> {
+    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
+        let mut this = Self::new();
+        this.extend(iter);
         this
     }
 }

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -59,7 +59,6 @@ use crate::utils::{PollState, PollVec, WakerVec};
 /// ```
 
 #[must_use = "`FutureGroup` does nothing if not iterated over"]
-#[derive(Default)]
 #[pin_project::pin_project]
 pub struct FutureGroup<F> {
     #[pin]
@@ -77,6 +76,12 @@ impl<T: Debug> Debug for FutureGroup<T> {
             .field("len", &self.len())
             .field("capacity", &self.capacity)
             .finish()
+    }
+}
+
+impl<T> Default for FutureGroup<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
This benchmark aims to measure latency between futures becoming ready and the stream producing them.
The bench currently shows `FutureGroup` trailing significantly behind `FuturesUnordered` for larger test sizes.

```
~/c/futures-concurrency (new-future-group-bench)> cargo bench future_group_poll_latency
    Finished bench [optimized + debuginfo] target(s) in 0.05s
     Running benches/bench.rs (target/release/deps/bench-26d01e1345f7786c)
Gnuplot not found, using plotters backend
future_group_poll_latency/FutureGroup/Params { init_size: 10, pct_ready_per_round: 0.001 }                                                                             
                        time:   [630.81 ns 631.56 ns 632.24 ns]
                        change: [+7.1846% +7.2671% +7.3558%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
future_group_poll_latency/FuturesUnordered/Params { init_size: 10, pct_ready_per_round: 0.001 }                                                                             
                        time:   [466.72 ns 469.05 ns 471.58 ns]
                        change: [-1.7131% -1.2735% -0.8808%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  14 (14.00%) low severe
  3 (3.00%) low mild
future_group_poll_latency/FutureGroup/Params { init_size: 10, pct_ready_per_round: 0.2 }                                                                             
                        time:   [537.25 ns 539.50 ns 541.62 ns]
                        change: [+2.5562% +2.9383% +3.2572%] (p = 0.00 < 0.05)
                        Performance has regressed.
future_group_poll_latency/FuturesUnordered/Params { init_size: 10, pct_ready_per_round: 0.2 }                                                                             
                        time:   [366.65 ns 368.35 ns 369.97 ns]
                        change: [-2.7245% -2.4190% -2.0874%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 30 outliers among 100 measurements (30.00%)
  16 (16.00%) low severe
  4 (4.00%) low mild
  8 (8.00%) high mild
  2 (2.00%) high severe
future_group_poll_latency/FutureGroup/Params { init_size: 10, pct_ready_per_round: 1.0 }                                                                             
                        time:   [404.96 ns 410.50 ns 416.19 ns]
                        change: [+13.031% +13.890% +14.650%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  16 (16.00%) low severe
  1 (1.00%) low mild
future_group_poll_latency/FuturesUnordered/Params { init_size: 10, pct_ready_per_round: 1.0 }                                                                             
                        time:   [276.28 ns 276.34 ns 276.39 ns]
                        change: [-0.7471% -0.7059% -0.6578%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
future_group_poll_latency/FutureGroup/Params { init_size: 100, pct_ready_per_round: 0.001 }                                                                             
                        time:   [14.159 µs 14.207 µs 14.255 µs]
                        change: [+4.3452% +4.4973% +4.6408%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) low severe
  7 (7.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
future_group_poll_latency/FuturesUnordered/Params { init_size: 100, pct_ready_per_round: 0.001 }                                                                             
                        time:   [4.9547 µs 4.9589 µs 4.9646 µs]
                        change: [-1.6303% -1.2868% -0.9175%] (p = 0.00 < 0.05)
                        Change within noise threshold.
future_group_poll_latency/FutureGroup/Params { init_size: 100, pct_ready_per_round: 0.2 }                                                                             
                        time:   [11.181 µs 11.182 µs 11.184 µs]
                        change: [+2.6277% +2.6520% +2.6760%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
future_group_poll_latency/FuturesUnordered/Params { init_size: 100, pct_ready_per_round: 0.2 }                                                                             
                        time:   [2.9196 µs 2.9202 µs 2.9207 µs]
                        change: [-1.6521% -1.6239% -1.5951%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
future_group_poll_latency/FutureGroup/Params { init_size: 100, pct_ready_per_round: 1.0 }                                                                             
                        time:   [4.0768 µs 4.0777 µs 4.0787 µs]
                        change: [-0.3427% +0.0016% +0.2321%] (p = 1.00 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
future_group_poll_latency/FuturesUnordered/Params { init_size: 100, pct_ready_per_round: 1.0 }                                                                             
                        time:   [2.7793 µs 2.7796 µs 2.7801 µs]
                        change: [-6.4224% -6.2342% -6.0593%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  8 (8.00%) high severe
Benchmarking future_group_poll_latency/FutureGroup/Params { init_size: 1000, pct_ready_per_round: 0.001 }: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.4s, enable flat sampling, or reduce sample count to 60.
future_group_poll_latency/FutureGroup/Params { init_size: 1000, pct_ready_per_round: 0.001 }                                                                             
                        time:   [1.0431 ms 1.0460 ms 1.0488 ms]
                        change: [-0.7482% -0.5783% -0.3925%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) high mild
  19 (19.00%) high severe
future_group_poll_latency/FuturesUnordered/Params { init_size: 1000, pct_ready_per_round: 0.001 }                                                                            
                        time:   [52.312 µs 52.334 µs 52.362 µs]
                        change: [-0.0070% +0.0275% +0.0639%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
future_group_poll_latency/FutureGroup/Params { init_size: 1000, pct_ready_per_round: 0.2 }                                                                            
                        time:   [826.35 µs 828.36 µs 830.13 µs]
                        change: [+1.3397% +1.7624% +2.2118%] (p = 0.00 < 0.05)
                        Performance has regressed.
future_group_poll_latency/FuturesUnordered/Params { init_size: 1000, pct_ready_per_round: 0.2 }                                                                            
                        time:   [30.896 µs 31.006 µs 31.109 µs]
                        change: [-1.8062% -1.4034% -1.0374%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
future_group_poll_latency/FutureGroup/Params { init_size: 1000, pct_ready_per_round: 1.0 }                                                                            
                        time:   [44.534 µs 44.610 µs 44.675 µs]
                        change: [+2.2008% +2.3854% +2.5792%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 25 outliers among 100 measurements (25.00%)
  4 (4.00%) low severe
  21 (21.00%) high severe
future_group_poll_latency/FuturesUnordered/Params { init_size: 1000, pct_ready_per_round: 1.0 }                                                                            
                        time:   [31.036 µs 31.122 µs 31.203 µs]
                        change: [-0.0946% +0.2297% +0.6345%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

     Running benches/compare.rs (target/release/deps/compare-430c491dda6e2002)
Gnuplot not found, using plotters backend```