### PR TITLE
Add checks for msrv and semver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,3 +91,11 @@ jobs:
 
     - name: Docs
       run: cargo doc
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,13 @@ jobs:
         command: test
         args: --all
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: taiki-e/install-action@cargo-hack
+    - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+
   miri:
     name: "Build and test (miri, nightly)"
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 keywords = []
 categories = []
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+rust-version = "1.75.0"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ documentation = "https://docs.rs/futures-concurrency"
 description = "Structured concurrency operations for async Rust"
 readme = "README.md"
 edition = "2021"
-keywords = []
-categories = []
+keywords = ["async", "concurrency"]
+categories = ["asynchronous", "concurrency"]
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 rust-version = "1.75.0"
 


### PR DESCRIPTION
declare the Minimum Supported Rust Version and add a check for it in CI. the msrv was identified using `cargo-msrv`.

i also took the opportunity to fill the `keywords` and `categories` on the cargo manifest, and, more importantly, add a CI step for `cargo-semver-checks`. the crate is gaining more features and users (!!), it's important not to break semver expectations.

Closes #180