### PR TITLE
Fix markdown punctuation in documentation of ConcurrentStream::take

### DIFF
--- a/src/concurrent_stream/mod.rs
+++ b/src/concurrent_stream/mod.rs
@@ -133,7 +133,7 @@ pub trait ConcurrentStream {
         Limit::new(self, limit)
     }
 
-    /// Creates a stream that yields the first `n`` elements, or fewer if the
+    /// Creates a stream that yields the first `n` elements, or fewer if the
     /// underlying iterator ends sooner.
     fn take(self, limit: usize) -> Take<Self>
     where


### PR DESCRIPTION
**Before:**
![Screenshot from 2024-05-06 11-23-57](https://github.com/yoshuawuyts/futures-concurrency/assets/1940490/5bff885c-17b1-4056-9420-a8ebc2ebc563)

**After:**
![Screenshot from 2024-05-06 11-24-08](https://github.com/yoshuawuyts/futures-concurrency/assets/1940490/03084a07-83c0-4e4b-8a7c-ada1d95d78d4)