### PR TITLE
fix: `clippy::doc_lazy_continuation`

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -66,7 +66,7 @@
 //!
 //! - `future::TryMerge`: wait for all futures in the set to complete _successfully_, or return on the first error.
 //! - `future::RaceOk`: wait for the first _successful_ future in the set to
-//! complete, or return an `Err` if *no* futures complete successfully.
+//!    complete, or return an `Err` if *no* futures complete successfully.
 //!
 #[doc(inline)]
 #[cfg(feature = "alloc")]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -30,12 +30,12 @@
 //! iterators:
 //!
 //! - `merge`: combine multiple iterators into a single iterator, where the new
-//! iterator yields an item as soon as one is available from one of the
-//! underlying iterators.
+//!   iterator yields an item as soon as one is available from one of the
+//!   underlying iterators.
 //! - `zip`: combine multiple iterators into an iterator of pairs. The
-//! underlying iterators will be awaited concurrently.
+//!   underlying iterators will be awaited concurrently.
 //! - `chain`: iterate over multiple iterators in sequence. The next iterator in
-//! the sequence won't start until the previous iterator has finished.
+//!   the sequence won't start until the previous iterator has finished.
 //!
 //! ## Futures
 //!


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation

Was introduced recently, and now makes PRs fail.