### PR TITLE
fix no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ harness = false
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = ["dep:fixedbitset", "dep:slab", "dep:smallvec"]
+std = ["alloc", "futures-lite/std"]
+alloc = ["dep:fixedbitset", "dep:slab", "dep:smallvec", "futures-lite/alloc"]
 
 [dependencies]
 fixedbitset = { version = "0.5.7", default-features = false, optional = true }
 futures-core = { version = "0.3", default-features = false }
-futures-lite = "1.12.0"
+futures-lite = { version = "1.12.0", default-features = false }
 pin-project = "1.0.8"
 slab = { version = "0.4.8", optional = true }
 smallvec = { version = "1.11.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ futures-lite = { version = "1.12.0", default-features = false }
 pin-project = "1.0.8"
 slab = { version = "0.4.8", optional = true }
 smallvec = { version = "1.11.0", optional = true }
-futures-buffered = "0.2.6"
+futures-buffered = "0.2.9"
 
 [dev-dependencies]
 async-io = "2.3.2"


### PR DESCRIPTION
Fixes `no_std` after after futures-buffered accepts https://github.com/conradludgate/futures-buffered/pull/9.

`futures-lite` has `std` and `alloc` features by default which had to be disabled unless the same feature is enabled in this crate.