### PR TITLE
Don't include default features of slab

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ fixedbitset = { version = "0.5.7", default-features = false, optional = true }
 futures-core = { version = "0.3", default-features = false }
 futures-lite = { version = "2.5.0", default-features = false }
 pin-project = "1.1"
-slab = { version = "0.4.9", optional = true }
+slab = { version = "0.4.9", optional = true, default-features = false }
 smallvec = { version = "1.13", optional = true }
 futures-buffered = "0.2.9"
 


### PR DESCRIPTION
`slab` includes the `std` feature by default which won't work for `no_std` projects. I can't really reproduce the problem by just building the project by itself but when pulling in `futures-concurrency` in my `no_std`/`embassy` project, I get errors such as:
```
cannot find type `Option` in this scope
not found in this scope   
```

Fix is simply to exclude default features from `slab`. Seems to work even when `std` features is enabled for `futures-concurrency`.