### PR TITLE
Add up to 15 join/try_join tuple items

### DIFF
--- a/src/future/join/tuple.rs
+++ b/src/future/join/tuple.rs
@@ -47,7 +47,7 @@ macro_rules! unsafe_poll {
 
     // macro start
     ($iteration:ident, $this:ident, $futures:ident, $cx:ident, $LEN:ident, $($F:ident,)+) => {
-        unsafe_poll!(@inner $iteration, $this, $futures, $cx, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11);
+        unsafe_poll!(@inner $iteration, $this, $futures, $cx, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14);
     };
 }
 
@@ -69,7 +69,7 @@ macro_rules! drop_initialized_values {
 
     // macro start
     ($($outs:ident,)+ | $states:expr) => {
-        drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,);
+        drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }
 
@@ -92,7 +92,7 @@ macro_rules! drop_pending_futures {
 
     // macro start
     ($states:ident, $futures:ident, $($F:ident,)+) => {
-        drop_pending_futures!(@inner $states, $futures, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11);
+        drop_pending_futures!(@inner $states, $futures, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14);
     };
 }
 
@@ -290,6 +290,9 @@ impl_join_tuple! { join9 Join9 A B C D E F G H I }
 impl_join_tuple! { join10 Join10 A B C D E F G H I J }
 impl_join_tuple! { join11 Join11 A B C D E F G H I J K }
 impl_join_tuple! { join12 Join12 A B C D E F G H I J K L }
+impl_join_tuple! { join13 Join13 A B C D E F G H I J K L M }
+impl_join_tuple! { join14 Join14 A B C D E F G H I J K L M N }
+impl_join_tuple! { join15 Join15 A B C D E F G H I J K L M N O }
 
 #[cfg(test)]
 mod test {

--- a/src/future/try_join/tuple.rs
+++ b/src/future/try_join/tuple.rs
@@ -72,7 +72,7 @@ macro_rules! unsafe_poll {
 
     // macro start
     ($iteration:ident, $this:ident, $futures:ident, $cx:ident, $LEN:ident, $($F:ident,)+) => {
-        unsafe_poll!(@inner $iteration, $this, $futures, $cx, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11);
+        unsafe_poll!(@inner $iteration, $this, $futures, $cx, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14);
     };
 }
 
@@ -94,7 +94,7 @@ macro_rules! drop_initialized_values {
 
     // macro start
     ($($outs:ident,)+ | $states:expr) => {
-        drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,);
+        drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }
 
@@ -117,7 +117,7 @@ macro_rules! drop_pending_futures {
 
     // macro start
     ($states:ident, $futures:ident, $($F:ident,)+) => {
-        drop_pending_futures!(@inner $states, $futures, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11);
+        drop_pending_futures!(@inner $states, $futures, $($F)+ | 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14);
     };
 }
 
@@ -329,6 +329,9 @@ impl_try_join_tuple! { try_join_9 TryJoin9 (A ResA) (B ResB) (C ResC) (D ResD) (
 impl_try_join_tuple! { try_join_10 TryJoin10 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) }
 impl_try_join_tuple! { try_join_11 TryJoin11 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) (K ResK) }
 impl_try_join_tuple! { try_join_12 TryJoin12 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) (K ResK) (L ResL) }
+impl_try_join_tuple! { try_join_13 TryJoin13 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) (K ResK) (L ResL) (M ResM) }
+impl_try_join_tuple! { try_join_14 TryJoin14 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) (K ResK) (L ResL) (M ResM) (N ResN) }
+impl_try_join_tuple! { try_join_15 TryJoin15 (A ResA) (B ResB) (C ResC) (D ResD) (E ResE) (F ResF) (G ResG) (H ResH) (I ResI) (J ResJ) (K ResK) (L ResL) (M ResM) (N ResN) (O ResO) }
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Hello! Thank you so much for your create!

I work on a screen reader called Odilia.
When we get a new item we have not seen before, we asynchronously grab all the fields of the item at once.
Since each field is a different type, we use `try_join!`.

We recently added a few new fields that go over the limit of the `(...).try_join` implementation.
This PR makes the maximum 15 futures instead of 12.
