### PR TITLE
fix: prepare for edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 keywords = ["async", "concurrency"]
 categories = ["asynchronous", "concurrency"]
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 
 [profile.bench]
 debug = true
@@ -39,9 +39,6 @@ pin-project = "1.1"
 slab = { version = "0.4.9", optional = true }
 smallvec = { version = "1.13", optional = true }
 futures-buffered = { version = "0.2.9", optional = true }
-
-[patch.crates-io]
-half = { version = "2.4.1", git = "https://github.com/VoidStarKat/half-rs.git", tag = "v2.4.1" }
 
 [dev-dependencies]
 async-io = "2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ futures-buffered = { version = "0.2.9", optional = true }
 [dev-dependencies]
 async-io = "2.4"
 async-std = { version = "1.13.0", features = ["attributes"] }
-criterion = { version = "0.5", features = [
+criterion = { version = "0.7", features = [
     "async",
     "async_futures",
     "html_reports",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ criterion = { version = "0.5", features = [
 ] }
 futures = "0.3"
 futures-time = "3.0.0"
-itertools = "0.13"
+itertools = "0.14"
 lending-stream = "1.0.1"
-rand = "0.8.5"
+rand = "0.9.1"
 tokio = { version = "1.41", features = ["macros", "time", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ slab = { version = "0.4.9", optional = true }
 smallvec = { version = "1.13", optional = true }
 futures-buffered = { version = "0.2.9", optional = true }
 
+[patch.crates-io]
+half = { version = "2.4.1", git = "https://github.com/VoidStarKat/half-rs.git", tag = "v2.4.1" }
+
 [dev-dependencies]
 async-io = "2.4"
 async-std = { version = "1.13.0", features = ["attributes"] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -19,10 +19,11 @@ fn main() {
 
 mod stream_group {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{black_box, criterion_group, BatchSize, BenchmarkId, Criterion};
+    use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
     use futures::stream::SelectAll;
     use futures_concurrency::stream::StreamGroup;
     use futures_lite::prelude::*;
+    use std::hint::black_box;
 
     use crate::utils::{make_select_all, make_stream_group};
     criterion_group! {
@@ -69,10 +70,11 @@ mod stream_group {
 }
 mod future_group {
     use std::fmt::{Debug, Display};
+    use std::hint::black_box;
     use std::time::{Duration, Instant};
 
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{black_box, criterion_group, BatchSize, BenchmarkId, Criterion};
+    use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
     use futures::channel::oneshot;
     use futures::never::Never;
     use futures::stream::FuturesUnordered;
@@ -237,10 +239,11 @@ mod future_group {
 
 mod merge {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{black_box, criterion_group, Criterion};
+    use criterion::{criterion_group, Criterion};
     use futures_concurrency::prelude::*;
     use futures_lite::future::block_on;
     use futures_lite::prelude::*;
+    use std::hint::black_box;
 
     use super::utils::{streams_array, streams_tuple, streams_vec};
 
@@ -321,8 +324,9 @@ mod merge {
 
 mod join {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{black_box, criterion_group, Criterion};
+    use criterion::{criterion_group, Criterion};
     use futures_concurrency::prelude::*;
+    use std::hint::black_box;
 
     use super::utils::{futures_array, futures_tuple, futures_vec};
 
@@ -386,8 +390,9 @@ mod join {
 
 mod race {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{black_box, criterion_group, Criterion};
+    use criterion::{criterion_group, Criterion};
     use futures_concurrency::prelude::*;
+    use std::hint::black_box;
 
     use crate::utils::futures_tuple;
 

--- a/src/future/join/tuple.rs
+++ b/src/future/join/tuple.rs
@@ -54,7 +54,7 @@ macro_rules! unsafe_poll {
 /// Drop all initialized values
 macro_rules! drop_initialized_values {
     // recursively iterate
-    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr_2021, $state_idx:tt, $($rem_idx:tt,)*) => {
+    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr, $state_idx:tt, $($rem_idx:tt,)*) => {
         if $states[$state_idx].is_ready() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
@@ -65,10 +65,10 @@ macro_rules! drop_initialized_values {
     };
 
     // base condition
-    (@drop | $states:expr_2021, $($rem_idx:tt,)*) => {};
+    (@drop | $states:expr, $($rem_idx:tt,)*) => {};
 
     // macro start
-    ($($outs:ident,)+ | $states:expr_2021) => {
+    ($($outs:ident,)+ | $states:expr) => {
         drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }

--- a/src/future/join/tuple.rs
+++ b/src/future/join/tuple.rs
@@ -54,7 +54,7 @@ macro_rules! unsafe_poll {
 /// Drop all initialized values
 macro_rules! drop_initialized_values {
     // recursively iterate
-    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr, $state_idx:tt, $($rem_idx:tt,)*) => {
+    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr_2021, $state_idx:tt, $($rem_idx:tt,)*) => {
         if $states[$state_idx].is_ready() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
@@ -65,10 +65,10 @@ macro_rules! drop_initialized_values {
     };
 
     // base condition
-    (@drop | $states:expr, $($rem_idx:tt,)*) => {};
+    (@drop | $states:expr_2021, $($rem_idx:tt,)*) => {};
 
     // macro start
-    ($($outs:ident,)+ | $states:expr) => {
+    ($($outs:ident,)+ | $states:expr_2021) => {
         drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }
@@ -246,7 +246,7 @@ macro_rules! impl_join_tuple {
             fn drop(self: Pin<&mut Self>) {
                 let this = self.project();
 
-                let ($(ref mut $F,)+) = this.outputs;
+                let &mut ($(ref mut $F,)+) = this.outputs;
 
                 let states = this.state;
                 let mut futures = this.futures;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -18,7 +18,7 @@
 //!     let b = future::ready(2);
 //!     let c = future::ready(3);
 //!     assert_eq!([a, b, c].join().await, [1, 2, 3]);
-//!    
+//!
 //!     // Await multiple differently-typed futures.
 //!     let a = future::ready(1u8);
 //!     let b = future::ready("hello");

--- a/src/future/try_join/tuple.rs
+++ b/src/future/try_join/tuple.rs
@@ -79,7 +79,7 @@ macro_rules! unsafe_poll {
 /// Drop all initialized values
 macro_rules! drop_initialized_values {
     // recursively iterate
-    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr, $state_idx:tt, $($rem_idx:tt,)*) => {
+    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr_2021, $state_idx:tt, $($rem_idx:tt,)*) => {
         if $states[$state_idx].is_ready() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
@@ -90,10 +90,10 @@ macro_rules! drop_initialized_values {
     };
 
     // base condition
-    (@drop | $states:expr, $($rem_idx:tt,)*) => {};
+    (@drop | $states:expr_2021, $($rem_idx:tt,)*) => {};
 
     // macro start
-    ($($outs:ident,)+ | $states:expr) => {
+    ($($outs:ident,)+ | $states:expr_2021) => {
         drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }
@@ -280,7 +280,7 @@ macro_rules! impl_try_join_tuple {
             fn drop(self: Pin<&mut Self>) {
                 let this = self.project();
 
-                let ($(ref mut $F,)+) = this.outputs;
+                let &mut ($(ref mut $F,)+) = this.outputs;
 
                 let states = this.state;
                 let mut futures = this.futures;

--- a/src/future/try_join/tuple.rs
+++ b/src/future/try_join/tuple.rs
@@ -79,7 +79,7 @@ macro_rules! unsafe_poll {
 /// Drop all initialized values
 macro_rules! drop_initialized_values {
     // recursively iterate
-    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr_2021, $state_idx:tt, $($rem_idx:tt,)*) => {
+    (@drop $output:ident, $($rem_outs:ident,)* | $states:expr, $state_idx:tt, $($rem_idx:tt,)*) => {
         if $states[$state_idx].is_ready() {
             // SAFETY: we've just filtered down to *only* the initialized values.
             // We can assume they're initialized, and this is where we drop them.
@@ -90,10 +90,10 @@ macro_rules! drop_initialized_values {
     };
 
     // base condition
-    (@drop | $states:expr_2021, $($rem_idx:tt,)*) => {};
+    (@drop | $states:expr, $($rem_idx:tt,)*) => {};
 
     // macro start
-    ($($outs:ident,)+ | $states:expr_2021) => {
+    ($($outs:ident,)+ | $states:expr) => {
         drop_initialized_values!(@drop $($outs,)+ | $states, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,);
     };
 }

--- a/src/utils/poll_state/maybe_done.rs
+++ b/src/utils/poll_state/maybe_done.rs
@@ -37,10 +37,9 @@ where
             MaybeDone::Done(Ok(_)) => {}
             MaybeDone::Done(Err(_)) | MaybeDone::Future(_) | MaybeDone::Gone => return None,
         }
-        if let MaybeDone::Done(Ok(output)) = mem::replace(this, MaybeDone::Gone) {
-            Some(output)
-        } else {
-            unreachable!()
+        match mem::replace(this, MaybeDone::Gone) {
+            MaybeDone::Done(Ok(output)) => Some(output),
+            _ => unreachable!(),
         }
     }
 
@@ -53,10 +52,9 @@ where
             MaybeDone::Done(Err(_)) => {}
             MaybeDone::Done(Ok(_)) | MaybeDone::Future(_) | MaybeDone::Gone => return None,
         }
-        if let MaybeDone::Done(Err(output)) = mem::replace(this, MaybeDone::Gone) {
-            Some(output)
-        } else {
-            unreachable!()
+        match mem::replace(this, MaybeDone::Gone) {
+            MaybeDone::Done(Err(output)) => Some(output),
+            _ => unreachable!(),
         }
     }
 }

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -17,7 +17,7 @@
 // - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
 macro_rules! gen_conditions {
     // Base condition, setup the depth counter.
-    ($i:expr, $this:expr, $cx:expr, $method:ident, $(($F_index: expr; $F:ident, { $($arms:pat => $foo:expr,)* }))*) => {
+    ($i:expr_2021, $this:expr_2021, $cx:expr_2021, $method:ident, $(($F_index: expr_2021; $F:ident, { $($arms:pat => $foo:expr_2021,)* }))*) => {
         $(
             if $i == $F_index {
                 match unsafe { Pin::new_unchecked(&mut $this.$F) }.$method($cx) {

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -17,7 +17,7 @@
 // - https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html
 macro_rules! gen_conditions {
     // Base condition, setup the depth counter.
-    ($i:expr_2021, $this:expr_2021, $cx:expr_2021, $method:ident, $(($F_index: expr_2021; $F:ident, { $($arms:pat => $foo:expr_2021,)* }))*) => {
+    ($i:expr, $this:expr, $cx:expr, $method:ident, $(($F_index: expr; $F:ident, { $($arms:pat => $foo:expr,)* }))*) => {
         $(
             if $i == $F_index {
                 match unsafe { Pin::new_unchecked(&mut $this.$F) }.$method($cx) {


### PR DESCRIPTION
### Fixes
- `cargo fix --edition` (2021 -> 2024, but had to revert unstable expr_2021)
- Some clippy warnings preventing CI to complete
- Bump MSRV to 1.81.0 to allow dependency upgrades (criterion [_bench_], half [_indirect_])

Fixes #202