### PR TITLE
chore: bump to edition 2024

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,42 +20,34 @@ jobs:
         rust: [stable]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
 
     - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         override: true
 
     - name: check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --bins --examples
+      run: |
+        cargo check --all --bins --examples
 
     - name: check no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --no-default-features
+      run: |
+        cargo check --all --no-default-features
 
     - name: check alloc
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --no-default-features --features alloc
+      run: |
+        cargo check --all --no-default-features --features alloc
 
     - name: tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all
+      run: |
+        cargo test --all
 
   msrv:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: taiki-e/install-action@cargo-hack
     - run: cargo hack check --rust-version --workspace --lib --ignore-private
 
@@ -63,7 +55,7 @@ jobs:
     name: "Build and test (miri, nightly)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri
@@ -76,8 +68,8 @@ jobs:
     name: Checking clippy, fmt and docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v5
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
         components: rustfmt, clippy
@@ -96,6 +88,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ repository = "https://github.com/yoshuawuyts/futures-concurrency"
 documentation = "https://docs.rs/futures-concurrency"
 description = "Structured concurrency operations for async Rust"
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 keywords = ["async", "concurrency"]
 categories = ["asynchronous", "concurrency"]
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
-rust-version = "1.81.0"
+rust-version = "1.85.1"
 
 [profile.bench]
 debug = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -19,7 +19,7 @@ fn main() {
 
 mod stream_group {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
+    use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group};
     use futures::stream::SelectAll;
     use futures_concurrency::stream::StreamGroup;
     use futures_lite::prelude::*;
@@ -74,7 +74,7 @@ mod future_group {
     use std::time::{Duration, Instant};
 
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
+    use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group};
     use futures::channel::oneshot;
     use futures::never::Never;
     use futures::stream::FuturesUnordered;
@@ -82,7 +82,7 @@ mod future_group {
     use futures_lite::future::yield_now;
     use futures_lite::prelude::*;
     use itertools::Itertools;
-    use rand::{seq::SliceRandom, SeedableRng};
+    use rand::{SeedableRng, seq::SliceRandom};
 
     use crate::utils::{make_future_group, make_futures_unordered};
     criterion_group! {
@@ -239,7 +239,7 @@ mod future_group {
 
 mod merge {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{criterion_group, Criterion};
+    use criterion::{Criterion, criterion_group};
     use futures_concurrency::prelude::*;
     use futures_lite::future::block_on;
     use futures_lite::prelude::*;
@@ -324,7 +324,7 @@ mod merge {
 
 mod join {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{criterion_group, Criterion};
+    use criterion::{Criterion, criterion_group};
     use futures_concurrency::prelude::*;
     use std::hint::black_box;
 
@@ -390,7 +390,7 @@ mod join {
 
 mod race {
     use criterion::async_executor::FuturesExecutor;
-    use criterion::{criterion_group, Criterion};
+    use criterion::{Criterion, criterion_group};
     use futures_concurrency::prelude::*;
     use std::hint::black_box;
 

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,5 +1,5 @@
 use criterion::async_executor::FuturesExecutor;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures_concurrency::prelude::*;
 
 mod utils;
@@ -47,8 +47,18 @@ fn select_vs_merge(c: &mut Criterion) {
             use futures::stream::StreamExt;
 
             // Create two streams of numbers. Both streams require being `fuse`d.
-            let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j] =
-                utils::streams_array::<N>().map(|fut| fut.fuse());
+            let [
+                mut a,
+                mut b,
+                mut c,
+                mut d,
+                mut e,
+                mut f,
+                mut g,
+                mut h,
+                mut i,
+                mut j,
+            ] = utils::streams_array::<N>().map(|fut| fut.fuse());
 
             // Initialize the output counter.
             let mut total = 0usize;

--- a/benches/utils/countdown_futures.rs
+++ b/benches/utils/countdown_futures.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use super::{shuffle, PrioritizedWaker, State};
+use super::{PrioritizedWaker, State, shuffle};
 
 pub fn futures_vec(len: usize) -> Vec<CountdownFuture> {
     let wakers = Rc::new(RefCell::new(BinaryHeap::new()));

--- a/benches/utils/countdown_streams.rs
+++ b/benches/utils/countdown_streams.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use super::{shuffle, PrioritizedWaker, State};
+use super::{PrioritizedWaker, State, shuffle};
 
 #[allow(unused)]
 pub fn streams_vec(len: usize) -> Vec<CountdownStream> {

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -36,8 +36,8 @@ enum State {
 }
 
 fn shuffle<T>(slice: &mut [T]) {
-    use rand::seq::SliceRandom;
     use rand::SeedableRng;
+    use rand::seq::SliceRandom;
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
     slice.shuffle(&mut rng);
 }

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -7,7 +7,7 @@
 
 use crate::concurrent_stream::{self, FromStream};
 use crate::prelude::*;
-use crate::utils::{from_iter, FromIter};
+use crate::utils::{FromIter, from_iter};
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
 use core::future::Ready;

--- a/src/concurrent_stream/enumerate.rs
+++ b/src/concurrent_stream/enumerate.rs
@@ -4,7 +4,7 @@ use super::{ConcurrentStream, Consumer};
 use core::future::Future;
 use core::num::NonZeroUsize;
 use core::pin::Pin;
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 /// A concurrent iterator that yields the current count and the element during iteration.
 ///
@@ -128,8 +128,8 @@ where
 mod test {
     // use crate::concurrent_stream::{ConcurrentStream, IntoConcurrentStream};
     use crate::prelude::*;
-    use futures_lite::stream;
     use futures_lite::StreamExt;
+    use futures_lite::stream;
     use std::num::NonZeroUsize;
 
     #[test]

--- a/src/concurrent_stream/for_each.rs
+++ b/src/concurrent_stream/for_each.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use core::num::NonZeroUsize;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 // OK: validated! - all bounds should check out
 #[pin_project]

--- a/src/concurrent_stream/from_stream.rs
+++ b/src/concurrent_stream/from_stream.rs
@@ -2,7 +2,7 @@ use super::Consumer;
 use crate::concurrent_stream::ConsumerState;
 use crate::prelude::*;
 
-use core::future::{ready, Ready};
+use core::future::{Ready, ready};
 use core::num::NonZeroUsize;
 use core::pin::pin;
 use futures_lite::{Stream, StreamExt};

--- a/src/concurrent_stream/map.rs
+++ b/src/concurrent_stream/map.rs
@@ -6,7 +6,7 @@ use core::{
     future::Future,
     marker::PhantomData,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 /// Convert items from one type into another

--- a/src/concurrent_stream/try_for_each.rs
+++ b/src/concurrent_stream/try_for_each.rs
@@ -12,7 +12,7 @@ use core::num::NonZeroUsize;
 use core::ops::ControlFlow;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 #[pin_project]
 pub(crate) struct TryForEachConsumer<FutT, T, F, FutB, B>

--- a/src/future/future_group.rs
+++ b/src/future/future_group.rs
@@ -3,8 +3,8 @@ use core::fmt::{self, Debug};
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use futures_core::stream::Stream;
 use futures_core::Future;
+use futures_core::stream::Stream;
 use slab::Slab;
 
 use crate::utils::{PollState, PollVec, WakerVec};

--- a/src/future/futures_ext.rs
+++ b/src/future/futures_ext.rs
@@ -3,9 +3,9 @@ use crate::future::Race;
 use core::future::IntoFuture;
 use futures_core::Future;
 
+use super::WaitUntil;
 use super::join::tuple::Join2;
 use super::race::tuple::Race2;
-use super::WaitUntil;
 
 /// An extension trait for the `Future` trait.
 pub trait FutureExt: Future {

--- a/src/future/race_ok/array/mod.rs
+++ b/src/future/race_ok/array/mod.rs
@@ -1,7 +1,7 @@
 use super::RaceOk as RaceOkTrait;
+use crate::utils::PollArray;
 use crate::utils::array_assume_init;
 use crate::utils::iter_pin_mut;
-use crate::utils::PollArray;
 
 use core::array;
 use core::fmt;

--- a/src/future/race_ok/vec/mod.rs
+++ b/src/future/race_ok/vec/mod.rs
@@ -1,6 +1,6 @@
 use super::RaceOk as RaceOkTrait;
-use crate::utils::iter_pin_mut;
 use crate::utils::MaybeDone;
+use crate::utils::iter_pin_mut;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{boxed::Box, vec::Vec};

--- a/src/future/wait_until.rs
+++ b/src/future/wait_until.rs
@@ -1,6 +1,6 @@
 use core::future::Future;
 use core::pin::Pin;
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 /// Suspends a future until the specified deadline.
 ///

--- a/src/stream/stream_ext.rs
+++ b/src/stream/stream_ext.rs
@@ -6,7 +6,7 @@ use futures_core::Stream;
 #[cfg(feature = "alloc")]
 use crate::concurrent_stream::FromStream;
 
-use super::{chain::tuple::Chain2, merge::tuple::Merge2, zip::tuple::Zip2, Chain, WaitUntil, Zip};
+use super::{Chain, WaitUntil, Zip, chain::tuple::Chain2, merge::tuple::Merge2, zip::tuple::Zip2};
 
 /// An extension trait for the `Stream` trait.
 pub trait StreamExt: Stream {

--- a/src/stream/stream_group.rs
+++ b/src/stream/stream_group.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures_core::Stream;
 use slab::Slab;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::utils::{PollState, PollVec, WakerVec};
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,4 +41,4 @@ pub(crate) use wakers::DummyWaker;
 pub(crate) mod channel;
 
 #[cfg(feature = "alloc")]
-pub(crate) use stream::{from_iter, FromIter};
+pub(crate) use stream::{FromIter, from_iter};

--- a/src/utils/poll_state/maybe_done.rs
+++ b/src/utils/poll_state/maybe_done.rs
@@ -1,7 +1,7 @@
 use core::future::Future;
 use core::mem;
 use core::pin::Pin;
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 /// A future that may have completed.
 #[derive(Debug)]

--- a/src/utils/poll_state/vec.rs
+++ b/src/utils/poll_state/vec.rs
@@ -1,5 +1,5 @@
 use core::ops::{Deref, DerefMut};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use super::PollState;
 
@@ -102,7 +102,7 @@ impl DerefMut for PollVec {
 
 #[cfg(test)]
 mod tests {
-    use super::{PollVec, MAX_INLINE_ENTRIES};
+    use super::{MAX_INLINE_ENTRIES, PollVec};
 
     #[test]
     fn type_size() {

--- a/tests/regression-155.rs
+++ b/tests/regression-155.rs
@@ -9,7 +9,7 @@
 use futures_concurrency::prelude::*;
 use futures_core::Future;
 use std::{future::ready, pin::Pin};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 


### PR DESCRIPTION
### Chores
- Bump edition 2021 to 2024
- Bump MSRV to 1.85.1 (required for edition 2024)
- Apply new formatting
- Update github-actions and replace unmaintained actions
- Let dependabot update cargo and github-actions