### PR TITLE
Fix pinned drop violations; make types Unpin where practical

### DIFF
--- a/src/concurrent_stream/for_each.rs
+++ b/src/concurrent_stream/for_each.rs
@@ -1,7 +1,6 @@
 use super::{Consumer, ConsumerState};
 use crate::future::FutureGroup;
 use futures_lite::StreamExt;
-use pin_project::pin_project;
 
 use alloc::sync::Arc;
 use core::future::Future;
@@ -66,7 +65,7 @@ where
     type Output = ();
 
     async fn send(self: Pin<&mut Self>, future: FutT) -> super::ConsumerState {
-        let mut this = self.get_mut();
+        let this = self.get_mut();
         // If we have no space, we're going to provide backpressure until we have space
         while this.count.load(Ordering::Relaxed) >= this.limit {
             this.group.next().await;

--- a/src/concurrent_stream/from_concurrent_stream.rs
+++ b/src/concurrent_stream/from_concurrent_stream.rs
@@ -41,9 +41,7 @@ impl<T, E> FromConcurrentStream<Result<T, E>> for Result<Vec<T>, E> {
 }
 
 // TODO: replace this with a generalized `fold` operation
-#[pin_project]
 pub(crate) struct VecConsumer<'a, Fut: Future> {
-    #[pin]
     group: FutureGroup<Fut>,
     output: &'a mut Vec<Fut::Output>,
 }
@@ -63,31 +61,28 @@ where
 {
     type Output = ();
 
-    async fn send(self: Pin<&mut Self>, future: Fut) -> super::ConsumerState {
-        let mut this = self.project();
+    async fn send(mut self: Pin<&mut Self>, future: Fut) -> super::ConsumerState {
         // unbounded concurrency, so we just goooo
-        this.group.as_mut().insert_pinned(future);
+        self.group.insert(future);
         ConsumerState::Continue
     }
 
     async fn progress(self: Pin<&mut Self>) -> super::ConsumerState {
-        let mut this = self.project();
+        let this = self.get_mut();
         while let Some(item) = this.group.next().await {
             this.output.push(item);
         }
         ConsumerState::Empty
     }
     async fn flush(self: Pin<&mut Self>) -> Self::Output {
-        let mut this = self.project();
+        let this = self.get_mut();
         while let Some(item) = this.group.next().await {
             this.output.push(item);
         }
     }
 }
 
-#[pin_project]
 pub(crate) struct ResultVecConsumer<'a, Fut: Future, T, E> {
-    #[pin]
     group: FutureGroup<Fut>,
     output: &'a mut Result<Vec<T>, E>,
 }
@@ -107,15 +102,14 @@ where
 {
     type Output = ();
 
-    async fn send(self: Pin<&mut Self>, future: Fut) -> super::ConsumerState {
-        let mut this = self.project();
+    async fn send(mut self: Pin<&mut Self>, future: Fut) -> super::ConsumerState {
         // unbounded concurrency, so we just goooo
-        this.group.as_mut().insert_pinned(future);
+        self.group.insert(future);
         ConsumerState::Continue
     }
 
     async fn progress(self: Pin<&mut Self>) -> super::ConsumerState {
-        let mut this = self.project();
+        let this = self.get_mut();
         let Ok(items) = this.output else {
             return ConsumerState::Break;
         };
@@ -126,7 +120,7 @@ where
                     items.push(item);
                 }
                 Err(e) => {
-                    **this.output = Err(e);
+                    *this.output = Err(e);
                     return ConsumerState::Break;
                 }
             }

--- a/src/concurrent_stream/from_concurrent_stream.rs
+++ b/src/concurrent_stream/from_concurrent_stream.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 use core::future::Future;
 use core::pin::Pin;
 use futures_lite::StreamExt;
-use pin_project::pin_project;
 
 /// Conversion from a [`ConcurrentStream`]
 #[allow(async_fn_in_trait)]

--- a/src/concurrent_stream/try_for_each.rs
+++ b/src/concurrent_stream/try_for_each.rs
@@ -72,7 +72,7 @@ where
     type Output = B;
 
     async fn send(self: Pin<&mut Self>, future: FutT) -> super::ConsumerState {
-        let mut this = self.get_mut();
+        let this = self.get_mut();
         // If we have no space, we're going to provide backpressure until we have space
         while this.count.load(Ordering::Relaxed) >= this.limit {
             match this.group.next().await {
@@ -103,7 +103,7 @@ where
     }
 
     async fn progress(self: Pin<&mut Self>) -> super::ConsumerState {
-        let mut this = self.get_mut();
+        let this = self.get_mut();
         while let Some(res) = this.group.next().await {
             if let ControlFlow::Break(residual) = res.branch() {
                 this.residual = Some(residual);
@@ -114,7 +114,7 @@ where
     }
 
     async fn flush(self: Pin<&mut Self>) -> Self::Output {
-        let mut this = self.get_mut();
+        let this = self.get_mut();
         // Return the error if we stopped iteration because of a previous error.
         if this.residual.is_some() {
             return B::from_residual(this.residual.take().unwrap());

--- a/src/utils/chunked_vec.rs
+++ b/src/utils/chunked_vec.rs
@@ -197,9 +197,9 @@ impl<T> Drop for ChunkedVec<T> {
                 // SAFETY
                 // 1. We're iterating over occupied indices, so this is initialized
                 // 2. The value is dropped in-place
-                // 3. If drop_in_place panics, the pinned memory is not deallocated
                 let element = &mut chunks[chunk][offset];
                 ptr::drop_in_place(element.as_mut_ptr());
+                // If drop_in_place panicked, the remaining memory isn't dropped
             }
         }
         unsafe {


### PR DESCRIPTION
I was writing a library of my own and decided to test this one. Although I had seen that #188 described pinning problems, I only discovered the extent of this myself, when this library began failing my code's anti-move checks.

This PR shores up the pin-on-drop problem. Pinned types have to be dropped in the same place, and ChunkedVec wasn't doing this.

### Changes summary

* FutureGroup and StreamGroup are now `Unpin` types. At heart, they kinda always were (see below)
* ChunkedVec is now built around pinning, fulfilling its destiny as a data structure made specifically for pinnable data
* Brief changes to tests, to catch the bug that spawned this PR to begin with

### Unpinned collections

Properly speaking, neither FutureGroup nor StreamGroup need to be pinned. The futures/streams are placed in allocations managed by ChunkedVec, which is responsible for keeping the futures/streams pinned. This has been true. In fact, this means the entire pin_project/`#[pin]` management done by these types was superfluous. FutureGroup and StreamGroup don't store any pinnable data inline, not even when the implementation used Slab.

Going forward, these types can be safely exposed as Unpin. Even if their implementation changes again, FutureGroup and StreamGroup are never going to store their streams/futures on stack. Only inline storage makes pinning self-referential data meaningful; heap storage will always be stable. Thus, making them Unpin is totally safe from the perspective of future compatibility.

### Growing streams and polling them too

As a side effect of making FutureGroup and StreamGroup `Unpin` types, they can now have items added to them even after they've been pinned. This was already the case for `Unpin` items, but now it will be true for `!Unpin` types as well.

This was alluded to in #188: by requiring the group to be pinned in order to be polled, the size becomes frozen and new insertions are impossible. I didn't investigate the previous version of futures-concurrency very much, but "freezing" the collection might be the only reason it used pinning.

That said, abandoning that design is surely for the better, and I don't think future implementations of this crate would ever need to bring it back. It was more of a side effect and a quirk of how the crate was implemened.